### PR TITLE
Fix TSX test information.

### DIFF
--- a/cpuid_test.go
+++ b/cpuid_test.go
@@ -634,14 +634,14 @@ func TestVM(t *testing.T) {
 	t.Log("Vendor ID:", CPU.VM())
 }
 
-// NSC returns true if vendor is recognized as National Semiconductor
+// TSX returns true if cpu supports transactional sync extensions.
 func TestCPUInfo_TSX(t *testing.T) {
 	got := CPU.TSX()
 	expected := CPU.HLE() && CPU.RTM()
 	if got != expected {
-		t.Fatalf("TestNSC: expected %v, got %v", expected, got)
+		t.Fatalf("TestCPUInfo_TSX: expected %v, got %v", expected, got)
 	}
-	t.Log("TestNSC:", got)
+	t.Log("TestCPUInfo_TSX:", got)
 }
 
 // Test RTCounter function


### PR DESCRIPTION
I'm kind of curious what the value of these tests is, as they depend entirely on the processor you run them on and are only reproducible if you run them on the same processor. Maybe there should be a mockCPU? Most of the bit comparisons are also a bit too easy though. Anyway... 