### PR TITLE
SGX EPC memory size detection support

### DIFF
--- a/cpuid_test.go
+++ b/cpuid_test.go
@@ -282,6 +282,17 @@ func TestSGX(t *testing.T) {
 		t.Fatalf("SGX: expected %v, got %v", expected, got)
 	}
 	t.Log("SGX Support:", got)
+
+	var total uint64 = 0
+	if CPU.SGX.Available {
+		for _, s := range CPU.SGX.EPCSections {
+			t.Logf("SGX EPC section: base address 0x%x, size %v", s.BaseAddress, s.EPCSize)
+			total += s.EPCSize
+		}
+		if total == 0 {
+			t.Fatal("SGX enabled without any available EPC memory")
+		}
+	}
 }
 
 // TestSGXLC tests SGX Launch Control detection


### PR DESCRIPTION
Iterate through the SGX EPC section subleaves. This can be used to find out the enclave memory size.

The reference for the bit operations is at https://software.intel.com/sites/default/files/managed/c5/15/architecture-instruction-set-extensions-programming-reference.pdf (page 1-19).
