### PR TITLE
Detect CPUID flag 7 features (AVX512)

### DIFF
--- a/cpuid.go
+++ b/cpuid.go
@@ -31,58 +31,66 @@ const (
 )
 
 const (
-	CMOV        = 1 << iota // i686 CMOV
-	NX                      // NX (No-Execute) bit
-	AMD3DNOW                // AMD 3DNOW
-	AMD3DNOWEXT             // AMD 3DNowExt
-	MMX                     // standard MMX
-	MMXEXT                  // SSE integer functions or AMD MMX ext
-	SSE                     // SSE functions
-	SSE2                    // P4 SSE functions
-	SSE3                    // Prescott SSE3 functions
-	SSSE3                   // Conroe SSSE3 functions
-	SSE4                    // Penryn SSE4.1 functions
-	SSE4A                   // AMD Barcelona microarchitecture SSE4a instructions
-	SSE42                   // Nehalem SSE4.2 functions
-	AVX                     // AVX functions
-	AVX2                    // AVX2 functions
-	FMA3                    // Intel FMA 3
-	FMA4                    // Bulldozer FMA4 functions
-	XOP                     // Bulldozer XOP functions
-	F16C                    // Half-precision floating-point conversion
-	BMI1                    // Bit Manipulation Instruction Set 1
-	BMI2                    // Bit Manipulation Instruction Set 2
-	TBM                     // AMD Trailing Bit Manipulation
-	LZCNT                   // LZCNT instruction
-	POPCNT                  // POPCNT instruction
-	AESNI                   // Advanced Encryption Standard New Instructions
-	CLMUL                   // Carry-less Multiplication
-	HTT                     // Hyperthreading (enabled)
-	HLE                     // Hardware Lock Elision
-	RTM                     // Restricted Transactional Memory
-	RDRAND                  // RDRAND instruction is available
-	RDSEED                  // RDSEED instruction is available
-	ADX                     // Intel ADX (Multi-Precision Add-Carry Instruction Extensions)
-	SHA                     // Intel SHA Extensions
-	AVX512F                 // AVX-512 Foundation
-	AVX512DQ                // AVX-512 Doubleword and Quadword Instructions
-	AVX512IFMA              // AVX-512 Integer Fused Multiply-Add Instructions
-	AVX512PF                // AVX-512 Prefetch Instructions
-	AVX512ER                // AVX-512 Exponential and Reciprocal Instructions
-	AVX512CD                // AVX-512 Conflict Detection Instructions
-	AVX512BW                // AVX-512 Byte and Word Instructions
-	AVX512VL                // AVX-512 Vector Length Extensions
-	AVX512VBMI              // AVX-512 Vector Bit Manipulation Instructions
-	AVX512VNNI              // AVX-512 Vector Neural Network Instructions
-	MPX                     // Intel MPX (Memory Protection Extensions)
-	ERMS                    // Enhanced REP MOVSB/STOSB
-	RDTSCP                  // RDTSCP Instruction
-	CX16                    // CMPXCHG16B Instruction
-	SGX                     // Software Guard Extensions
-	SGXLC                   // Software Guard Extensions Launch Control
-	IBPB                    // Indirect Branch Restricted Speculation (IBRS) and Indirect Branch Predictor Barrier (IBPB)
-	STIBP                   // Single Thread Indirect Branch Predictors
-	VMX                     // Virtual Machine Extensions
+	CMOV                = 1 << iota // i686 CMOV
+	NX                              // NX (No-Execute) bit
+	AMD3DNOW                        // AMD 3DNOW
+	AMD3DNOWEXT                     // AMD 3DNowExt
+	MMX                             // standard MMX
+	MMXEXT                          // SSE integer functions or AMD MMX ext
+	SSE                             // SSE functions
+	SSE2                            // P4 SSE functions
+	SSE3                            // Prescott SSE3 functions
+	SSSE3                           // Conroe SSSE3 functions
+	SSE4                            // Penryn SSE4.1 functions
+	SSE4A                           // AMD Barcelona microarchitecture SSE4a instructions
+	SSE42                           // Nehalem SSE4.2 functions
+	AVX                             // AVX functions
+	AVX2                            // AVX2 functions
+	FMA3                            // Intel FMA 3
+	FMA4                            // Bulldozer FMA4 functions
+	XOP                             // Bulldozer XOP functions
+	F16C                            // Half-precision floating-point conversion
+	BMI1                            // Bit Manipulation Instruction Set 1
+	BMI2                            // Bit Manipulation Instruction Set 2
+	TBM                             // AMD Trailing Bit Manipulation
+	LZCNT                           // LZCNT instruction
+	POPCNT                          // POPCNT instruction
+	AESNI                           // Advanced Encryption Standard New Instructions
+	CLMUL                           // Carry-less Multiplication
+	HTT                             // Hyperthreading (enabled)
+	HLE                             // Hardware Lock Elision
+	RTM                             // Restricted Transactional Memory
+	RDRAND                          // RDRAND instruction is available
+	RDSEED                          // RDSEED instruction is available
+	ADX                             // Intel ADX (Multi-Precision Add-Carry Instruction Extensions)
+	SHA                             // Intel SHA Extensions
+	AVX512F                         // AVX-512 Foundation
+	AVX512DQ                        // AVX-512 Doubleword and Quadword Instructions
+	AVX512IFMA                      // AVX-512 Integer Fused Multiply-Add Instructions
+	AVX512PF                        // AVX-512 Prefetch Instructions
+	AVX512ER                        // AVX-512 Exponential and Reciprocal Instructions
+	AVX512CD                        // AVX-512 Conflict Detection Instructions
+	AVX512BW                        // AVX-512 Byte and Word Instructions
+	AVX512VL                        // AVX-512 Vector Length Extensions
+	AVX512VBMI                      // AVX-512 Vector Bit Manipulation Instructions
+	AVX512_VBMI2                    // AVX-512 Vector Bit Manipulation Instructions, Version 2
+	AVX512_VNNI                     // AVX-512 Vector Neural Network Instructions
+	AVX512_VPOPCNTDQ                // AVX-512 Vector Population Count Doubleword and Quadword
+	GFNI                            // Galois Field New Instructions
+	VAES                            // Vector AES
+	AVX512_BITALG                   // AVX-512 Bit Algorithms
+	VPCLMULQDQ                      // Carry-Less Multiplication Quadword
+	AVX512_BF16                     // AVX-512 BFLOAT16 Instructions
+	AVX512_VP2INTERSECT             // AVX-512 Intersect for D/Q
+	MPX                             // Intel MPX (Memory Protection Extensions)
+	ERMS                            // Enhanced REP MOVSB/STOSB
+	RDTSCP                          // RDTSCP Instruction
+	CX16                            // CMPXCHG16B Instruction
+	SGX                             // Software Guard Extensions
+	SGXLC                           // Software Guard Extensions Launch Control
+	IBPB                            // Indirect Branch Restricted Speculation (IBRS) and Indirect Branch Predictor Barrier (IBPB)
+	STIBP                           // Single Thread Indirect Branch Predictors
+	VMX                             // Virtual Machine Extensions
 
 	// Performance indicators
 	SSE2SLOW // SSE2 is supported, but usually not faster
@@ -91,58 +99,66 @@ const (
 )
 
 var flagNames = map[Flags]string{
-	CMOV:        "CMOV",        // i686 CMOV
-	NX:          "NX",          // NX (No-Execute) bit
-	AMD3DNOW:    "AMD3DNOW",    // AMD 3DNOW
-	AMD3DNOWEXT: "AMD3DNOWEXT", // AMD 3DNowExt
-	MMX:         "MMX",         // Standard MMX
-	MMXEXT:      "MMXEXT",      // SSE integer functions or AMD MMX ext
-	SSE:         "SSE",         // SSE functions
-	SSE2:        "SSE2",        // P4 SSE2 functions
-	SSE3:        "SSE3",        // Prescott SSE3 functions
-	SSSE3:       "SSSE3",       // Conroe SSSE3 functions
-	SSE4:        "SSE4.1",      // Penryn SSE4.1 functions
-	SSE4A:       "SSE4A",       // AMD Barcelona microarchitecture SSE4a instructions
-	SSE42:       "SSE4.2",      // Nehalem SSE4.2 functions
-	AVX:         "AVX",         // AVX functions
-	AVX2:        "AVX2",        // AVX functions
-	FMA3:        "FMA3",        // Intel FMA 3
-	FMA4:        "FMA4",        // Bulldozer FMA4 functions
-	XOP:         "XOP",         // Bulldozer XOP functions
-	F16C:        "F16C",        // Half-precision floating-point conversion
-	BMI1:        "BMI1",        // Bit Manipulation Instruction Set 1
-	BMI2:        "BMI2",        // Bit Manipulation Instruction Set 2
-	TBM:         "TBM",         // AMD Trailing Bit Manipulation
-	LZCNT:       "LZCNT",       // LZCNT instruction
-	POPCNT:      "POPCNT",      // POPCNT instruction
-	AESNI:       "AESNI",       // Advanced Encryption Standard New Instructions
-	CLMUL:       "CLMUL",       // Carry-less Multiplication
-	HTT:         "HTT",         // Hyperthreading (enabled)
-	HLE:         "HLE",         // Hardware Lock Elision
-	RTM:         "RTM",         // Restricted Transactional Memory
-	RDRAND:      "RDRAND",      // RDRAND instruction is available
-	RDSEED:      "RDSEED",      // RDSEED instruction is available
-	ADX:         "ADX",         // Intel ADX (Multi-Precision Add-Carry Instruction Extensions)
-	SHA:         "SHA",         // Intel SHA Extensions
-	AVX512F:     "AVX512F",     // AVX-512 Foundation
-	AVX512DQ:    "AVX512DQ",    // AVX-512 Doubleword and Quadword Instructions
-	AVX512IFMA:  "AVX512IFMA",  // AVX-512 Integer Fused Multiply-Add Instructions
-	AVX512PF:    "AVX512PF",    // AVX-512 Prefetch Instructions
-	AVX512ER:    "AVX512ER",    // AVX-512 Exponential and Reciprocal Instructions
-	AVX512CD:    "AVX512CD",    // AVX-512 Conflict Detection Instructions
-	AVX512BW:    "AVX512BW",    // AVX-512 Byte and Word Instructions
-	AVX512VL:    "AVX512VL",    // AVX-512 Vector Length Extensions
-	AVX512VBMI:  "AVX512VBMI",  // AVX-512 Vector Bit Manipulation Instructions
-	AVX512VNNI:  "AVX512VNNI",  // AVX-512 Vector Neural Network Instructions
-	MPX:         "MPX",         // Intel MPX (Memory Protection Extensions)
-	ERMS:        "ERMS",        // Enhanced REP MOVSB/STOSB
-	RDTSCP:      "RDTSCP",      // RDTSCP Instruction
-	CX16:        "CX16",        // CMPXCHG16B Instruction
-	SGX:         "SGX",         // Software Guard Extensions
-	SGXLC:       "SGXLC",       // Software Guard Extensions Launch Control
-	IBPB:        "IBPB",        // Indirect Branch Restricted Speculation and Indirect Branch Predictor Barrier
-	STIBP:       "STIBP",       // Single Thread Indirect Branch Predictors
-	VMX:         "VMX",         // Virtual Machine Extensions
+	CMOV:                "CMOV",                // i686 CMOV
+	NX:                  "NX",                  // NX (No-Execute) bit
+	AMD3DNOW:            "AMD3DNOW",            // AMD 3DNOW
+	AMD3DNOWEXT:         "AMD3DNOWEXT",         // AMD 3DNowExt
+	MMX:                 "MMX",                 // Standard MMX
+	MMXEXT:              "MMXEXT",              // SSE integer functions or AMD MMX ext
+	SSE:                 "SSE",                 // SSE functions
+	SSE2:                "SSE2",                // P4 SSE2 functions
+	SSE3:                "SSE3",                // Prescott SSE3 functions
+	SSSE3:               "SSSE3",               // Conroe SSSE3 functions
+	SSE4:                "SSE4.1",              // Penryn SSE4.1 functions
+	SSE4A:               "SSE4A",               // AMD Barcelona microarchitecture SSE4a instructions
+	SSE42:               "SSE4.2",              // Nehalem SSE4.2 functions
+	AVX:                 "AVX",                 // AVX functions
+	AVX2:                "AVX2",                // AVX functions
+	FMA3:                "FMA3",                // Intel FMA 3
+	FMA4:                "FMA4",                // Bulldozer FMA4 functions
+	XOP:                 "XOP",                 // Bulldozer XOP functions
+	F16C:                "F16C",                // Half-precision floating-point conversion
+	BMI1:                "BMI1",                // Bit Manipulation Instruction Set 1
+	BMI2:                "BMI2",                // Bit Manipulation Instruction Set 2
+	TBM:                 "TBM",                 // AMD Trailing Bit Manipulation
+	LZCNT:               "LZCNT",               // LZCNT instruction
+	POPCNT:              "POPCNT",              // POPCNT instruction
+	AESNI:               "AESNI",               // Advanced Encryption Standard New Instructions
+	CLMUL:               "CLMUL",               // Carry-less Multiplication
+	HTT:                 "HTT",                 // Hyperthreading (enabled)
+	HLE:                 "HLE",                 // Hardware Lock Elision
+	RTM:                 "RTM",                 // Restricted Transactional Memory
+	RDRAND:              "RDRAND",              // RDRAND instruction is available
+	RDSEED:              "RDSEED",              // RDSEED instruction is available
+	ADX:                 "ADX",                 // Intel ADX (Multi-Precision Add-Carry Instruction Extensions)
+	SHA:                 "SHA",                 // Intel SHA Extensions
+	AVX512F:             "AVX512F",             // AVX-512 Foundation
+	AVX512DQ:            "AVX512DQ",            // AVX-512 Doubleword and Quadword Instructions
+	AVX512IFMA:          "AVX512IFMA",          // AVX-512 Integer Fused Multiply-Add Instructions
+	AVX512PF:            "AVX512PF",            // AVX-512 Prefetch Instructions
+	AVX512ER:            "AVX512ER",            // AVX-512 Exponential and Reciprocal Instructions
+	AVX512CD:            "AVX512CD",            // AVX-512 Conflict Detection Instructions
+	AVX512BW:            "AVX512BW",            // AVX-512 Byte and Word Instructions
+	AVX512VL:            "AVX512VL",            // AVX-512 Vector Length Extensions
+	AVX512VBMI:          "AVX512VBMI",          // AVX-512 Vector Bit Manipulation Instructions
+	AVX512_VBMI2:        "AVX512_VBMI2",        // AVX-512 Vector Bit Manipulation Instructions, Version 2
+	AVX512_VNNI:         "AVX512_VNNI",         // AVX-512 Vector Neural Network Instructions
+	AVX512_VPOPCNTDQ:    "AVX512_VPOPCNTDQ",    // AVX-512 Vector Population Count Doubleword and Quadword
+	GFNI:                "GFNI",                // Galois Field New Instructions
+	VAES:                "VAES",                // Vector AES
+	AVX512_BITALG:       "AVX512_BITALG",       // AVX-512 Bit Algorithms
+	VPCLMULQDQ:          "VPCLMULQDQ",          // Carry-Less Multiplication Quadword
+	AVX512_BF16:         "AVX512_BF16",         // AVX-512 BFLOAT16 Instruction
+	AVX512_VP2INTERSECT: "AVX512_VP2INTERSECT", // AVX-512 Intersect for D/Q
+	MPX:                 "MPX",                 // Intel MPX (Memory Protection Extensions)
+	ERMS:                "ERMS",                // Enhanced REP MOVSB/STOSB
+	RDTSCP:              "RDTSCP",              // RDTSCP Instruction
+	CX16:                "CX16",                // CMPXCHG16B Instruction
+	SGX:                 "SGX",                 // Software Guard Extensions
+	SGXLC:               "SGXLC",               // Software Guard Extensions Launch Control
+	IBPB:                "IBPB",                // Indirect Branch Restricted Speculation and Indirect Branch Predictor Barrier
+	STIBP:               "STIBP",               // Single Thread Indirect Branch Predictors
+	VMX:                 "VMX",                 // Virtual Machine Extensions
 
 	// Performance indicators
 	SSE2SLOW: "SSE2SLOW", // SSE2 supported, but usually not faster
@@ -444,9 +460,49 @@ func (c CPUInfo) AVX512VBMI() bool {
 	return c.Features&AVX512VBMI != 0
 }
 
-// AVX512VNNI indicates support of AVX-512 Vector Neural Network Instructions
-func (c CPUInfo) AVX512VNNI() bool {
-	return c.Features&AVX512VNNI != 0
+// AVX512_VBMI2 indicates support of AVX-512 Vector Bit Manipulation Instructions, Version 2
+func (c CPUInfo) AVX512_VBMI2() bool {
+	return c.Features&AVX512_VBMI2 != 0
+}
+
+// AVX512_VNNI indicates support of AVX-512 Vector Neural Network Instructions
+func (c CPUInfo) AVX512_VNNI() bool {
+	return c.Features&AVX512_VNNI != 0
+}
+
+// AVX512_VPOPCNTDQ indicates support of AVX-512 Vector Population Count Doubleword and Quadword
+func (c CPUInfo) AVX512_VPOPCNTDQ() bool {
+	return c.Features&AVX512_VPOPCNTDQ != 0
+}
+
+// GFNI indicates support of Galois Field New Instructions
+func (c CPUInfo) GFNI() bool {
+	return c.Features&GFNI != 0
+}
+
+// VAES indicates support of Vector AES
+func (c CPUInfo) VAES() bool {
+	return c.Features&VAES != 0
+}
+
+// AVX512_BITALG indicates support of AVX-512 Bit Algorithms
+func (c CPUInfo) AVX512_BITALG() bool {
+	return c.Features&AVX512_BITALG != 0
+}
+
+// VPCLMULQDQ indicates support of Carry-Less Multiplication Quadword
+func (c CPUInfo) VPCLMULQDQ() bool {
+	return c.Features&VPCLMULQDQ != 0
+}
+
+// AVX512_BF16 indicates support of
+func (c CPUInfo) AVX512_BF16() bool {
+	return c.Features&AVX512_BF16 != 0
+}
+
+// AVX512_VP2INTERSECT indicates support of
+func (c CPUInfo) AVX512_VP2INTERSECT() bool {
+	return c.Features&AVX512_VP2INTERSECT != 0
 }
 
 // MPX indicates support of Intel MPX (Memory Protection Extensions)
@@ -914,6 +970,7 @@ func support() Flags {
 	// Check AVX2, AVX2 requires OS support, but BMI1/2 don't.
 	if mfi >= 7 {
 		_, ebx, ecx, edx := cpuidex(7, 0)
+		eax1, _, _, _ := cpuidex(7, 1)
 		if (rval&AVX) != 0 && (ebx&0x00000020) != 0 {
 			rval |= AVX2
 		}
@@ -994,8 +1051,34 @@ func support() Flags {
 				if ecx&(1<<1) != 0 {
 					rval |= AVX512VBMI
 				}
+				if ecx&(1<<6) != 0 {
+					rval |= AVX512_VBMI2
+				}
+				if ecx&(1<<8) != 0 {
+					rval |= GFNI
+				}
+				if ecx&(1<<9) != 0 {
+					rval |= VAES
+				}
+				if ecx&(1<<10) != 0 {
+					rval |= VPCLMULQDQ
+				}
 				if ecx&(1<<11) != 0 {
-					rval |= AVX512VNNI
+					rval |= AVX512_VNNI
+				}
+				if ecx&(1<<12) != 0 {
+					rval |= AVX512_BITALG
+				}
+				if ecx&(1<<14) != 0 {
+					rval |= AVX512_VPOPCNTDQ
+				}
+				// edx
+				if edx&(1<<8) != 0 {
+					rval |= AVX512_VP2INTERSECT
+				}
+				// cpuid eax 07h,ecx=1
+				if eax1&(1<<5) != 0 {
+					rval |= AVX512_BF16
 				}
 			}
 		}

--- a/cpuid_test.go
+++ b/cpuid_test.go
@@ -585,14 +585,94 @@ func TestAVX512VBMI(t *testing.T) {
 	t.Log("AVX512VBMI Support:", got)
 }
 
-// TestAVX512VNNI tests AVX512VNNI() function (AVX-512 Vector Neural Network Instructions)
-func TestAVX512VNNI(t *testing.T) {
-	got := CPU.AVX512VNNI()
-	expected := CPU.Features&AVX512VNNI == AVX512VNNI
+// TestAVX512_VBMI2 tests AVX512_VBMI2 function (AVX-512 Vector Bit Manipulation Instructions, Version 2)
+func TestAVX512_VBMI2(t *testing.T) {
+	got := CPU.AVX512_VBMI2()
+	expected := CPU.Features&AVX512_VBMI2 == AVX512_VBMI2
 	if got != expected {
-		t.Fatalf("AVX512VNNI: expected %v, got %v", expected, got)
+		t.Fatalf("AVX512_VBMI2: expected %v, got %v", expected, got)
 	}
-	t.Log("AVX512VNNI Support:", got)
+	t.Log("AVX512_VBMI2 Support:", got)
+}
+
+// TestAVX512_VNNI tests AVX512_VNNI() function (AVX-512 Vector Neural Network Instructions)
+func TestAVX512_VNNI(t *testing.T) {
+	got := CPU.AVX512_VNNI()
+	expected := CPU.Features&AVX512_VNNI == AVX512_VNNI
+	if got != expected {
+		t.Fatalf("AVX512_VNNI: expected %v, got %v", expected, got)
+	}
+	t.Log("AVX512_VNNI Support:", got)
+}
+
+// TestAVX512_VPOPCNTDQ tests AVX512_VPOPCNTDQ() function (AVX-512 Vector Population Count Doubleword and Quadword)
+func TestAVX512_VPOPCNTDQ(t *testing.T) {
+	got := CPU.AVX512_VPOPCNTDQ()
+	expected := CPU.Features&AVX512_VPOPCNTDQ == AVX512_VPOPCNTDQ
+	if got != expected {
+		t.Fatalf("AVX512_VPOPCNTDQ: expected %v, got %v", expected, got)
+	}
+	t.Log("AVX512_VPOPCNTDQ Support:", got)
+}
+
+// TestGFNI tests GFNI() function (Galois Field New Instructions)
+func TestGFNI(t *testing.T) {
+	got := CPU.GFNI()
+	expected := CPU.Features&GFNI == GFNI
+	if got != expected {
+		t.Fatalf("GFNI: expected %v, got %v", expected, got)
+	}
+	t.Log("GFNI Support:", got)
+}
+
+// TestVAES tests VAES() function (Vector AES)
+func TestVAES(t *testing.T) {
+	got := CPU.VAES()
+	expected := CPU.Features&VAES == VAES
+	if got != expected {
+		t.Fatalf("VAES: expected %v, got %v", expected, got)
+	}
+	t.Log("VAES Support:", got)
+}
+
+// TestAVX512_BITALG tests AVX512_BITALG() function (AVX-512 Bit Algorithms)
+func TestAVX512_BITALG(t *testing.T) {
+	got := CPU.AVX512_BITALG()
+	expected := CPU.Features&AVX512_BITALG == AVX512_BITALG
+	if got != expected {
+		t.Fatalf("AVX512_BITALG: expected %v, got %v", expected, got)
+	}
+	t.Log("AVX512_BITALG Support:", got)
+}
+
+// TestVPCLMULQDQ tests VPCLMULQDQ() function (Carry-Less Multiplication Quadword)
+func TestVPCLMULQDQ(t *testing.T) {
+	got := CPU.VPCLMULQDQ()
+	expected := CPU.Features&VPCLMULQDQ == VPCLMULQDQ
+	if got != expected {
+		t.Fatalf("VPCLMULQDQ: expected %v, got %v", expected, got)
+	}
+	t.Log("VPCLMULQDQ Support:", got)
+}
+
+// TestAVX512_BF16 tests AVX512_BF16() function (AVX-512 BFLOAT16 Instructions)
+func TestAVX512_BF16(t *testing.T) {
+	got := CPU.AVX512_BF16()
+	expected := CPU.Features&AVX512_BF16 == AVX512_BF16
+	if got != expected {
+		t.Fatalf("AVX512_BF16: expected %v, got %v", expected, got)
+	}
+	t.Log("AVX512_BF16 Support:", got)
+}
+
+// TestAVX512_VP2INTERSECT tests AVX512_VP2INTERSECT() function (AVX-512 Intersect for D/Q)
+func TestAVX512_VP2INTERSECT(t *testing.T) {
+	got := CPU.AVX512_VP2INTERSECT()
+	expected := CPU.Features&AVX512_VP2INTERSECT == AVX512_VP2INTERSECT
+	if got != expected {
+		t.Fatalf("AVX512_VP2INTERSECT: expected %v, got %v", expected, got)
+	}
+	t.Log("AVX512_VP2INTERSECT Support:", got)
 }
 
 // TestMPX tests MPX() function (Intel MPX (Memory Protection Extensions))


### PR DESCRIPTION
Detect features:
- AVX512_VBMI2 (Vector Bit Manipulation Instructions, Version 2)
- AVX512_VNNI* (Vector Neural Network Instructions)
- AVX512_VPOPCNTDQ (Vector Population Count Doubleword and Quadword)
- GFNI (Galois Field New Instructions)
- VAES (Vector AES)
- AVX512_BITALG (AVX-512 Bit Algorithms)
- VPCLMULQDQ (Carry-Less Multiplication Quadword)
- AVX512_BF16 (AVX-512 BFLOAT16 Instructions)
- AVX512_VP2INTERSECT (AVX-512 Intersect for D/Q)

* Renames AVX512VNNI to AVX512_VNNI to keep naming in sync with
  Linux kernel and Intel Architecture Programming Reference

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>
Signed-off-by: Antti Kervinen <antti.kervinen@intel.com>