### PR TITLE
AMD Updates

### DIFF
--- a/private/cpuid_test.go
+++ b/private/cpuid_test.go
@@ -285,13 +285,15 @@ func TestSGX(t *testing.T) {
 	}
 	t.Log("SGX Support:", got)
 
-	var total uint64 = 0
 	if cpu.sgx.available {
+		var total uint64 = 0
+		leaves := false
 		for _, s := range cpu.sgx.epcsections {
 			t.Logf("SGX EPC section: base address 0x%x, size %v", s.baseaddress, s.epcsize)
 			total += s.epcsize
+			leaves = true
 		}
-		if total == 0 {
+		if leaves && total == 0 {
 			t.Fatal("SGX enabled without any available EPC memory")
 		}
 	}


### PR DESCRIPTION
Detect L3 cache size on AMD.
Detect hyperthreading on AMD.

Changes:

```diff
813c813
<     TestMocks: mockcpu_test.go:191: L3 Cache: -1 bytes
---
>     TestMocks: mockcpu_test.go:191: L3 Cache: 8388608 bytes
827c827
<     TestMocks: mockcpu_test.go:191: L3 Cache: -1 bytes
---
>     TestMocks: mockcpu_test.go:191: L3 Cache: 8388608 bytes
841c841
<     TestMocks: mockcpu_test.go:191: L3 Cache: -1 bytes
---
>     TestMocks: mockcpu_test.go:191: L3 Cache: 8388608 bytes
855c855
<     TestMocks: mockcpu_test.go:191: L3 Cache: -1 bytes
---
>     TestMocks: mockcpu_test.go:191: L3 Cache: 6291456 bytes
869c869
<     TestMocks: mockcpu_test.go:191: L3 Cache: -1 bytes
---
>     TestMocks: mockcpu_test.go:191: L3 Cache: 8388608 bytes
1065c1065
<     TestMocks: mockcpu_test.go:191: L3 Cache: -1 bytes
---
>     TestMocks: mockcpu_test.go:191: L3 Cache: 8388608 bytes
1079c1079
<     TestMocks: mockcpu_test.go:191: L3 Cache: -1 bytes
---
>     TestMocks: mockcpu_test.go:191: L3 Cache: 8388608 bytes
1093c1093
<     TestMocks: mockcpu_test.go:191: L3 Cache: -1 bytes
---
>     TestMocks: mockcpu_test.go:191: L3 Cache: 8388608 bytes
1107c1107
<     TestMocks: mockcpu_test.go:191: L3 Cache: -1 bytes
---
>     TestMocks: mockcpu_test.go:191: L3 Cache: 8388608 bytes
1121c1121
<     TestMocks: mockcpu_test.go:191: L3 Cache: -1 bytes
---
>     TestMocks: mockcpu_test.go:191: L3 Cache: 8388608 bytes
1135c1135
<     TestMocks: mockcpu_test.go:191: L3 Cache: -1 bytes
---
>     TestMocks: mockcpu_test.go:191: L3 Cache: 8388608 bytes
1149c1149
<     TestMocks: mockcpu_test.go:191: L3 Cache: -1 bytes
---
>     TestMocks: mockcpu_test.go:191: L3 Cache: 4194304 bytes
1163c1163
<     TestMocks: mockcpu_test.go:191: L3 Cache: -1 bytes
---
>     TestMocks: mockcpu_test.go:191: L3 Cache: 4194304 bytes
1177c1177
<     TestMocks: mockcpu_test.go:191: L3 Cache: -1 bytes
---
>     TestMocks: mockcpu_test.go:191: L3 Cache: 4194304 bytes
1182,1183c1182,1183
<     TestMocks: mockcpu_test.go:182: PhysicalCores: 128
<     TestMocks: mockcpu_test.go:183: ThreadsPerCore: 1
---
>     TestMocks: mockcpu_test.go:182: PhysicalCores: 64
>     TestMocks: mockcpu_test.go:183: ThreadsPerCore: 2
1186c1186
<     TestMocks: mockcpu_test.go:186: Features: CMOV,NX,MMX,MMXEXT,SSE,SSE2,SSE3,SSSE3,SSE4.1,SSE4A,SSE4.2,F16C,BMI1,BMI2,LZCNT,POPCNT,AESNI,CLMUL,RDRAND,RDSEED,ADX,SHA,RDTSCP,CX16
---
>     TestMocks: mockcpu_test.go:186: Features: CMOV,NX,MMX,MMXEXT,SSE,SSE2,SSE3,SSSE3,SSE4.1,SSE4A,SSE4.2,F16C,BMI1,BMI2,LZCNT,POPCNT,AESNI,CLMUL,HTT,RDRAND,RDSEED,ADX,SHA,RDTSCP,CX16
1191c1191
<     TestMocks: mockcpu_test.go:191: L3 Cache: -1 bytes
---
>     TestMocks: mockcpu_test.go:191: L3 Cache: 16777216 bytes
1196,1197c1196,1197
<     TestMocks: mockcpu_test.go:182: PhysicalCores: 64
<     TestMocks: mockcpu_test.go:183: ThreadsPerCore: 1
---
>     TestMocks: mockcpu_test.go:182: PhysicalCores: 32
>     TestMocks: mockcpu_test.go:183: ThreadsPerCore: 2
1200c1200
<     TestMocks: mockcpu_test.go:186: Features: CMOV,NX,MMX,MMXEXT,SSE,SSE2,SSE3,SSSE3,SSE4.1,SSE4A,SSE4.2,F16C,BMI1,BMI2,LZCNT,POPCNT,AESNI,CLMUL,RDRAND,RDSEED,ADX,SHA,RDTSCP,CX16
---
>     TestMocks: mockcpu_test.go:186: Features: CMOV,NX,MMX,MMXEXT,SSE,SSE2,SSE3,SSSE3,SSE4.1,SSE4A,SSE4.2,F16C,BMI1,BMI2,LZCNT,POPCNT,AESNI,CLMUL,HTT,RDRAND,RDSEED,ADX,SHA,RDTSCP,CX16
1205c1205
<     TestMocks: mockcpu_test.go:191: L3 Cache: -1 bytes
---
>     TestMocks: mockcpu_test.go:191: L3 Cache: 16777216 bytes
1709c1709
<     TestMocks: mockcpu_test.go:191: L3 Cache: -1 bytes
---
>     TestMocks: mockcpu_test.go:191: L3 Cache: 8388608 bytes
4022c4022
< ok  	github.com/klauspost/cpuid	0.241s
---
> ok  	github.com/klauspost/cpuid	0.242s
```