### PR TITLE
Fixed missing noasm tags

### DIFF
--- a/detect_intel.go
+++ b/detect_intel.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2015 Klaus Post, released under MIT License. See LICENSE file.
 
-//+build 386,!gccgo amd64,!gccgo,!noasm,!appengine
+//+build 386,!gccgo,!noasm amd64,!gccgo,!noasm,!appengine
 
 package cpuid
 

--- a/private/cpuid_detect_intel.go
+++ b/private/cpuid_detect_intel.go
@@ -2,7 +2,7 @@
 // but copy it to your own project and rename the package.
 // See more at http://github.com/klauspost/cpuid
 
-//+build 386,!gccgo amd64,!gccgo,!noasm,!appengine
+//+build 386,!gccgo,!noasm amd64,!gccgo,!noasm,!appengine
 
 package cpuid
 


### PR DESCRIPTION
It looks like `!noasm` tag in `detect_intel.go` only works for amd64. This PR adds `!noasm` for 386, too.