### PR TITLE
Move x86 CPU features from Flags to a FlagSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ package main
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/klauspost/cpuid"
 )
 
@@ -154,7 +156,7 @@ func main() {
 	fmt.Println("ThreadsPerCore:", cpuid.CPU.ThreadsPerCore)
 	fmt.Println("LogicalCores:", cpuid.CPU.LogicalCores)
 	fmt.Println("Family", cpuid.CPU.Family, "Model:", cpuid.CPU.Model)
-	fmt.Println("Features:", cpuid.CPU.Features)
+	fmt.Println("Features:", fmt.Sprintf(strings.Join(cpuid.CPU.FeatureSet(), ",")))
 	fmt.Println("Cacheline bytes:", cpuid.CPU.CacheLine)
 	fmt.Println("L1 Data Cache:", cpuid.CPU.Cache.L1D, "bytes")
 	fmt.Println("L1 Instruction Cache:", cpuid.CPU.Cache.L1D, "bytes")

--- a/cpuid.go
+++ b/cpuid.go
@@ -109,6 +109,8 @@ const (
 	AMXTILE // Tile architecture
 	AMXINT8 // Tile computational operations on 8-bit integers
 
+	HYPERVISOR // This bit has been reserved by Intel & AMD for use by hypervisors
+
 	// Keep it last. It automatically defines the size of []FlagSet
 	LASTID
 )
@@ -183,6 +185,8 @@ var flagNames = map[Flags]string{
 	AMXBF16: "AMXBF16", // Tile computational operations on BFLOAT16 numbers
 	AMXTILE: "AMXTILE", // Tile architecture
 	AMXINT8: "AMXINT8", // Tile computational operations on 8-bit integers
+
+	HYPERVISOR: "HYPERVISOR", // This bit has been reserved by Intel & AMD for use by hypervisors
 }
 
 /* all special features for arm64 should be defined here */
@@ -756,14 +760,9 @@ func hertz(model string) int64 {
 }
 
 // VM Will return true if the cpu id indicates we are in
-// a virtual machine. This is only a hint, and will very likely
-// have many false negatives.
+// a virtual machine.
 func (c CPUInfo) VM() bool {
-	switch c.VendorID {
-	case MSVM, KVM, VMware, XenHVM, Bhyve:
-		return true
-	}
-	return false
+	return CPU.featureSet.inSet(HYPERVISOR)
 }
 
 // Flags contains detected cpu features and characteristics
@@ -1205,6 +1204,11 @@ func support() FlagSet {
 	}
 	if c&(1<<30) != 0 {
 		fs.set(RDRAND)
+	}
+	// This bit has been reserved by Intel & AMD for use by hypervisors,
+	// and indicates the presence of a hypervisor.
+	if c&(1<<31) != 0 {
+		fs.set(HYPERVISOR)
 	}
 	if c&(1<<29) != 0 {
 		fs.set(F16C)

--- a/cpuid.go
+++ b/cpuid.go
@@ -39,71 +39,78 @@ const (
 )
 
 const (
-	CMOV               = 1 << iota // i686 CMOV
-	NX                             // NX (No-Execute) bit
-	AMD3DNOW                       // AMD 3DNOW
-	AMD3DNOWEXT                    // AMD 3DNowExt
-	MMX                            // standard MMX
-	MMXEXT                         // SSE integer functions or AMD MMX ext
-	SSE                            // SSE functions
-	SSE2                           // P4 SSE functions
-	SSE3                           // Prescott SSE3 functions
-	SSSE3                          // Conroe SSSE3 functions
-	SSE4                           // Penryn SSE4.1 functions
-	SSE4A                          // AMD Barcelona microarchitecture SSE4a instructions
-	SSE42                          // Nehalem SSE4.2 functions
-	AVX                            // AVX functions
-	AVX2                           // AVX2 functions
-	FMA3                           // Intel FMA 3
-	FMA4                           // Bulldozer FMA4 functions
-	XOP                            // Bulldozer XOP functions
-	F16C                           // Half-precision floating-point conversion
-	BMI1                           // Bit Manipulation Instruction Set 1
-	BMI2                           // Bit Manipulation Instruction Set 2
-	TBM                            // AMD Trailing Bit Manipulation
-	LZCNT                          // LZCNT instruction
-	POPCNT                         // POPCNT instruction
-	AESNI                          // Advanced Encryption Standard New Instructions
-	CLMUL                          // Carry-less Multiplication
-	HTT                            // Hyperthreading (enabled)
-	HLE                            // Hardware Lock Elision
-	RTM                            // Restricted Transactional Memory
-	RDRAND                         // RDRAND instruction is available
-	RDSEED                         // RDSEED instruction is available
-	ADX                            // Intel ADX (Multi-Precision Add-Carry Instruction Extensions)
-	SHA                            // Intel SHA Extensions
-	AVX512F                        // AVX-512 Foundation
-	AVX512DQ                       // AVX-512 Doubleword and Quadword Instructions
-	AVX512IFMA                     // AVX-512 Integer Fused Multiply-Add Instructions
-	AVX512PF                       // AVX-512 Prefetch Instructions
-	AVX512ER                       // AVX-512 Exponential and Reciprocal Instructions
-	AVX512CD                       // AVX-512 Conflict Detection Instructions
-	AVX512BW                       // AVX-512 Byte and Word Instructions
-	AVX512VL                       // AVX-512 Vector Length Extensions
-	AVX512VBMI                     // AVX-512 Vector Bit Manipulation Instructions
-	AVX512VBMI2                    // AVX-512 Vector Bit Manipulation Instructions, Version 2
-	AVX512VNNI                     // AVX-512 Vector Neural Network Instructions
-	AVX512VPOPCNTDQ                // AVX-512 Vector Population Count Doubleword and Quadword
-	GFNI                           // Galois Field New Instructions
-	VAES                           // Vector AES
-	AVX512BITALG                   // AVX-512 Bit Algorithms
-	VPCLMULQDQ                     // Carry-Less Multiplication Quadword
-	AVX512BF16                     // AVX-512 BFLOAT16 Instructions
-	AVX512VP2INTERSECT             // AVX-512 Intersect for D/Q
-	MPX                            // Intel MPX (Memory Protection Extensions)
-	ERMS                           // Enhanced REP MOVSB/STOSB
-	RDTSCP                         // RDTSCP Instruction
-	CX16                           // CMPXCHG16B Instruction
-	SGX                            // Software Guard Extensions
-	SGXLC                          // Software Guard Extensions Launch Control
-	IBPB                           // Indirect Branch Restricted Speculation (IBRS) and Indirect Branch Predictor Barrier (IBPB)
-	STIBP                          // Single Thread Indirect Branch Predictors
-	VMX                            // Virtual Machine Extensions
+	CMOV               = iota // i686 CMOV
+	NX                        // NX (No-Execute) bit
+	AMD3DNOW                  // AMD 3DNOW
+	AMD3DNOWEXT               // AMD 3DNowExt
+	MMX                       // standard MMX
+	MMXEXT                    // SSE integer functions or AMD MMX ext
+	SSE                       // SSE functions
+	SSE2                      // P4 SSE functions
+	SSE3                      // Prescott SSE3 functions
+	SSSE3                     // Conroe SSSE3 functions
+	SSE4                      // Penryn SSE4.1 functions
+	SSE4A                     // AMD Barcelona microarchitecture SSE4a instructions
+	SSE42                     // Nehalem SSE4.2 functions
+	AVX                       // AVX functions
+	AVX2                      // AVX2 functions
+	FMA3                      // Intel FMA 3
+	FMA4                      // Bulldozer FMA4 functions
+	XOP                       // Bulldozer XOP functions
+	F16C                      // Half-precision floating-point conversion
+	BMI1                      // Bit Manipulation Instruction Set 1
+	BMI2                      // Bit Manipulation Instruction Set 2
+	TBM                       // AMD Trailing Bit Manipulation
+	LZCNT                     // LZCNT instruction
+	POPCNT                    // POPCNT instruction
+	AESNI                     // Advanced Encryption Standard New Instructions
+	CLMUL                     // Carry-less Multiplication
+	HTT                       // Hyperthreading (enabled)
+	HLE                       // Hardware Lock Elision
+	RTM                       // Restricted Transactional Memory
+	RDRAND                    // RDRAND instruction is available
+	RDSEED                    // RDSEED instruction is available
+	ADX                       // Intel ADX (Multi-Precision Add-Carry Instruction Extensions)
+	SHA                       // Intel SHA Extensions
+	AVX512F                   // AVX-512 Foundation
+	AVX512DQ                  // AVX-512 Doubleword and Quadword Instructions
+	AVX512IFMA                // AVX-512 Integer Fused Multiply-Add Instructions
+	AVX512PF                  // AVX-512 Prefetch Instructions
+	AVX512ER                  // AVX-512 Exponential and Reciprocal Instructions
+	AVX512CD                  // AVX-512 Conflict Detection Instructions
+	AVX512BW                  // AVX-512 Byte and Word Instructions
+	AVX512VL                  // AVX-512 Vector Length Extensions
+	AVX512VBMI                // AVX-512 Vector Bit Manipulation Instructions
+	AVX512VBMI2               // AVX-512 Vector Bit Manipulation Instructions, Version 2
+	AVX512VNNI                // AVX-512 Vector Neural Network Instructions
+	AVX512VPOPCNTDQ           // AVX-512 Vector Population Count Doubleword and Quadword
+	GFNI                      // Galois Field New Instructions
+	VAES                      // Vector AES
+	AVX512BITALG              // AVX-512 Bit Algorithms
+	VPCLMULQDQ                // Carry-Less Multiplication Quadword
+	AVX512BF16                // AVX-512 BFLOAT16 Instructions
+	AVX512VP2INTERSECT        // AVX-512 Intersect for D/Q
+	MPX                       // Intel MPX (Memory Protection Extensions)
+	ERMS                      // Enhanced REP MOVSB/STOSB
+	RDTSCP                    // RDTSCP Instruction
+	CX16                      // CMPXCHG16B Instruction
+	SGX                       // Software Guard Extensions
+	SGXLC                     // Software Guard Extensions Launch Control
+	IBPB                      // Indirect Branch Restricted Speculation (IBRS) and Indirect Branch Predictor Barrier (IBPB)
+	STIBP                     // Single Thread Indirect Branch Predictors
+	VMX                       // Virtual Machine Extensions
 
 	// Performance indicators
 	SSE2SLOW // SSE2 is supported, but usually not faster
 	SSE3SLOW // SSE3 is supported, but usually not faster
 	ATOM     // Atom processor, some SSSE3 instructions are slower
+
+	AMXBF16 // Tile computational operations on BFLOAT16 numbers
+	AMXTILE // Tile architecture
+	AMXINT8 // Tile computational operations on 8-bit integers
+
+	// Keep it last. It automatically defines the size of []FlagSet
+	LASTID
 )
 
 var flagNames = map[Flags]string{
@@ -173,6 +180,9 @@ var flagNames = map[Flags]string{
 	SSE3SLOW: "SSE3SLOW", // SSE3 supported, but usually not faster
 	ATOM:     "ATOM",     // Atom processor, some SSSE3 instructions are slower
 
+	AMXBF16: "AMXBF16", // Tile computational operations on BFLOAT16 numbers
+	AMXTILE: "AMXTILE", // Tile architecture
+	AMXINT8: "AMXINT8", // Tile computational operations on 8-bit integers
 }
 
 /* all special features for arm64 should be defined here */
@@ -231,27 +241,14 @@ var flagNamesArm = map[ArmFlags]string{
 	GPA:      "GPA",      // Generic Pointer Authentication
 }
 
-// x86 Advanced Matrix Extensions features, in CPUInfo.AmxFeatures
-const (
-	AMXBF16 AmxFlags = 1 << iota // Tile computational operations on BFLOAT16 numbers
-	AMXTILE                      // Tile architecture
-	AMXINT8                      // Tile computational operations on 8-bit integers
-)
-
-var flagNamesAmx = map[AmxFlags]string{
-	AMXBF16: "AMXBF16", // Tile computational operations on BFLOAT16 numbers
-	AMXTILE: "AMXTILE", // Tile architecture
-	AMXINT8: "AMXINT8", // Tile computational operations on 8-bit integers
-}
-
 // CPUInfo contains information about the detected system CPU.
 type CPUInfo struct {
 	BrandName      string   // Brand name reported by the CPU
 	VendorID       Vendor   // Comparable CPU vendor ID
 	VendorString   string   // Raw vendor string.
-	Features       Flags    // Features of the CPU (x64)
+	Features       Flags    // Features of the CPU (x64) (deprecated)
+	featureSet     FlagSet  // Features of the CPU
 	Arm            ArmFlags // Features of the CPU (arm)
-	AmxFeatures    AmxFlags // Features of the AMX (x86 Advanced Matrix Extension)
 	PhysicalCores  int      // Number of physical processor cores in your CPU. Will be 0 if undetectable.
 	ThreadsPerCore int      // Number of threads per physical core. Will be 1 if undetectable.
 	LogicalCores   int      // Number of physical cores times threads that can run on each core through the use of hyperthreading. Will be 0 if undetectable.
@@ -307,323 +304,323 @@ func Detect() {
 
 // Cmov indicates support of CMOV instructions
 func (c CPUInfo) Cmov() bool {
-	return c.Features&CMOV != 0
+	return c.featureSet.inSet(CMOV)
 }
 
 // Amd3dnow indicates support of AMD 3DNOW! instructions
 func (c CPUInfo) Amd3dnow() bool {
-	return c.Features&AMD3DNOW != 0
+	return c.featureSet.inSet(AMD3DNOW)
 }
 
 // Amd3dnowExt indicates support of AMD 3DNOW! Extended instructions
 func (c CPUInfo) Amd3dnowExt() bool {
-	return c.Features&AMD3DNOWEXT != 0
+	return c.featureSet.inSet(AMD3DNOWEXT)
 }
 
 // VMX indicates support of VMX
 func (c CPUInfo) VMX() bool {
-	return c.Features&VMX != 0
+	return c.featureSet.inSet(VMX)
 }
 
 // MMX indicates support of MMX instructions
 func (c CPUInfo) MMX() bool {
-	return c.Features&MMX != 0
+	return c.featureSet.inSet(MMX)
 }
 
 // MMXExt indicates support of MMXEXT instructions
 // (SSE integer functions or AMD MMX ext)
 func (c CPUInfo) MMXExt() bool {
-	return c.Features&MMXEXT != 0
+	return c.featureSet.inSet(MMXEXT)
 }
 
 // SSE indicates support of SSE instructions
 func (c CPUInfo) SSE() bool {
-	return c.Features&SSE != 0
+	return c.featureSet.inSet(SSE)
 }
 
 // SSE2 indicates support of SSE 2 instructions
 func (c CPUInfo) SSE2() bool {
-	return c.Features&SSE2 != 0
+	return c.featureSet.inSet(SSE2)
 }
 
 // SSE3 indicates support of SSE 3 instructions
 func (c CPUInfo) SSE3() bool {
-	return c.Features&SSE3 != 0
+	return c.featureSet.inSet(SSE3)
 }
 
 // SSSE3 indicates support of SSSE 3 instructions
 func (c CPUInfo) SSSE3() bool {
-	return c.Features&SSSE3 != 0
+	return c.featureSet.inSet(SSSE3)
 }
 
 // SSE4 indicates support of SSE 4 (also called SSE 4.1) instructions
 func (c CPUInfo) SSE4() bool {
-	return c.Features&SSE4 != 0
+	return c.featureSet.inSet(SSE4)
 }
 
 // SSE42 indicates support of SSE4.2 instructions
 func (c CPUInfo) SSE42() bool {
-	return c.Features&SSE42 != 0
+	return c.featureSet.inSet(SSE42)
 }
 
 // AVX indicates support of AVX instructions
 // and operating system support of AVX instructions
 func (c CPUInfo) AVX() bool {
-	return c.Features&AVX != 0
+	return c.featureSet.inSet(AVX)
 }
 
 // AVX2 indicates support of AVX2 instructions
 func (c CPUInfo) AVX2() bool {
-	return c.Features&AVX2 != 0
+	return c.featureSet.inSet(AVX2)
 }
 
 // FMA3 indicates support of FMA3 instructions
 func (c CPUInfo) FMA3() bool {
-	return c.Features&FMA3 != 0
+	return c.featureSet.inSet(FMA3)
 }
 
 // FMA4 indicates support of FMA4 instructions
 func (c CPUInfo) FMA4() bool {
-	return c.Features&FMA4 != 0
+	return c.featureSet.inSet(FMA4)
 }
 
 // XOP indicates support of XOP instructions
 func (c CPUInfo) XOP() bool {
-	return c.Features&XOP != 0
+	return c.featureSet.inSet(XOP)
 }
 
 // F16C indicates support of F16C instructions
 func (c CPUInfo) F16C() bool {
-	return c.Features&F16C != 0
+	return c.featureSet.inSet(F16C)
 }
 
 // BMI1 indicates support of BMI1 instructions
 func (c CPUInfo) BMI1() bool {
-	return c.Features&BMI1 != 0
+	return c.featureSet.inSet(BMI1)
 }
 
 // BMI2 indicates support of BMI2 instructions
 func (c CPUInfo) BMI2() bool {
-	return c.Features&BMI2 != 0
+	return c.featureSet.inSet(BMI2)
 }
 
 // TBM indicates support of TBM instructions
 // (AMD Trailing Bit Manipulation)
 func (c CPUInfo) TBM() bool {
-	return c.Features&TBM != 0
+	return c.featureSet.inSet(TBM)
 }
 
 // Lzcnt indicates support of LZCNT instruction
 func (c CPUInfo) Lzcnt() bool {
-	return c.Features&LZCNT != 0
+	return c.featureSet.inSet(LZCNT)
 }
 
 // Popcnt indicates support of POPCNT instruction
 func (c CPUInfo) Popcnt() bool {
-	return c.Features&POPCNT != 0
+	return c.featureSet.inSet(POPCNT)
 }
 
 // HTT indicates the processor has Hyperthreading enabled
 func (c CPUInfo) HTT() bool {
-	return c.Features&HTT != 0
+	return c.featureSet.inSet(HTT)
 }
 
 // SSE2Slow indicates that SSE2 may be slow on this processor
 func (c CPUInfo) SSE2Slow() bool {
-	return c.Features&SSE2SLOW != 0
+	return c.featureSet.inSet(SSE2SLOW)
 }
 
 // SSE3Slow indicates that SSE3 may be slow on this processor
 func (c CPUInfo) SSE3Slow() bool {
-	return c.Features&SSE3SLOW != 0
+	return c.featureSet.inSet(SSE3SLOW)
 }
 
 // AesNi indicates support of AES-NI instructions
 // (Advanced Encryption Standard New Instructions)
 func (c CPUInfo) AesNi() bool {
-	return c.Features&AESNI != 0
+	return c.featureSet.inSet(AESNI)
 }
 
 // Clmul indicates support of CLMUL instructions
 // (Carry-less Multiplication)
 func (c CPUInfo) Clmul() bool {
-	return c.Features&CLMUL != 0
+	return c.featureSet.inSet(CLMUL)
 }
 
 // NX indicates support of NX (No-Execute) bit
 func (c CPUInfo) NX() bool {
-	return c.Features&NX != 0
+	return c.featureSet.inSet(NX)
 }
 
 // SSE4A indicates support of AMD Barcelona microarchitecture SSE4a instructions
 func (c CPUInfo) SSE4A() bool {
-	return c.Features&SSE4A != 0
+	return c.featureSet.inSet(SSE4A)
 }
 
 // HLE indicates support of Hardware Lock Elision
 func (c CPUInfo) HLE() bool {
-	return c.Features&HLE != 0
+	return c.featureSet.inSet(HLE)
 }
 
 // RTM indicates support of Restricted Transactional Memory
 func (c CPUInfo) RTM() bool {
-	return c.Features&RTM != 0
+	return c.featureSet.inSet(RTM)
 }
 
 // Rdrand indicates support of RDRAND instruction is available
 func (c CPUInfo) Rdrand() bool {
-	return c.Features&RDRAND != 0
+	return c.featureSet.inSet(RDRAND)
 }
 
 // Rdseed indicates support of RDSEED instruction is available
 func (c CPUInfo) Rdseed() bool {
-	return c.Features&RDSEED != 0
+	return c.featureSet.inSet(RDSEED)
 }
 
 // ADX indicates support of Intel ADX (Multi-Precision Add-Carry Instruction Extensions)
 func (c CPUInfo) ADX() bool {
-	return c.Features&ADX != 0
+	return c.featureSet.inSet(ADX)
 }
 
 // SHA indicates support of Intel SHA Extensions
 func (c CPUInfo) SHA() bool {
-	return c.Features&SHA != 0
+	return c.featureSet.inSet(SHA)
 }
 
 // AVX512F indicates support of AVX-512 Foundation
 func (c CPUInfo) AVX512F() bool {
-	return c.Features&AVX512F != 0
+	return c.featureSet.inSet(AVX512F)
 }
 
 // AVX512DQ indicates support of AVX-512 Doubleword and Quadword Instructions
 func (c CPUInfo) AVX512DQ() bool {
-	return c.Features&AVX512DQ != 0
+	return c.featureSet.inSet(AVX512DQ)
 }
 
 // AVX512IFMA indicates support of AVX-512 Integer Fused Multiply-Add Instructions
 func (c CPUInfo) AVX512IFMA() bool {
-	return c.Features&AVX512IFMA != 0
+	return c.featureSet.inSet(AVX512IFMA)
 }
 
 // AVX512PF indicates support of AVX-512 Prefetch Instructions
 func (c CPUInfo) AVX512PF() bool {
-	return c.Features&AVX512PF != 0
+	return c.featureSet.inSet(AVX512PF)
 }
 
 // AVX512ER indicates support of AVX-512 Exponential and Reciprocal Instructions
 func (c CPUInfo) AVX512ER() bool {
-	return c.Features&AVX512ER != 0
+	return c.featureSet.inSet(AVX512ER)
 }
 
 // AVX512CD indicates support of AVX-512 Conflict Detection Instructions
 func (c CPUInfo) AVX512CD() bool {
-	return c.Features&AVX512CD != 0
+	return c.featureSet.inSet(AVX512CD)
 }
 
 // AVX512BW indicates support of AVX-512 Byte and Word Instructions
 func (c CPUInfo) AVX512BW() bool {
-	return c.Features&AVX512BW != 0
+	return c.featureSet.inSet(AVX512BW)
 }
 
 // AVX512VL indicates support of AVX-512 Vector Length Extensions
 func (c CPUInfo) AVX512VL() bool {
-	return c.Features&AVX512VL != 0
+	return c.featureSet.inSet(AVX512VL)
 }
 
 // AVX512VBMI indicates support of AVX-512 Vector Bit Manipulation Instructions
 func (c CPUInfo) AVX512VBMI() bool {
-	return c.Features&AVX512VBMI != 0
+	return c.featureSet.inSet(AVX512VBMI)
 }
 
 // AVX512VBMI2 indicates support of AVX-512 Vector Bit Manipulation Instructions, Version 2
 func (c CPUInfo) AVX512VBMI2() bool {
-	return c.Features&AVX512VBMI2 != 0
+	return c.featureSet.inSet(AVX512VBMI2)
 }
 
 // AVX512VNNI indicates support of AVX-512 Vector Neural Network Instructions
 func (c CPUInfo) AVX512VNNI() bool {
-	return c.Features&AVX512VNNI != 0
+	return c.featureSet.inSet(AVX512VNNI)
 }
 
 // AVX512VPOPCNTDQ indicates support of AVX-512 Vector Population Count Doubleword and Quadword
 func (c CPUInfo) AVX512VPOPCNTDQ() bool {
-	return c.Features&AVX512VPOPCNTDQ != 0
+	return c.featureSet.inSet(AVX512VPOPCNTDQ)
 }
 
 // GFNI indicates support of Galois Field New Instructions
 func (c CPUInfo) GFNI() bool {
-	return c.Features&GFNI != 0
+	return c.featureSet.inSet(GFNI)
 }
 
 // VAES indicates support of Vector AES
 func (c CPUInfo) VAES() bool {
-	return c.Features&VAES != 0
+	return c.featureSet.inSet(VAES)
 }
 
 // AVX512BITALG indicates support of AVX-512 Bit Algorithms
 func (c CPUInfo) AVX512BITALG() bool {
-	return c.Features&AVX512BITALG != 0
+	return c.featureSet.inSet(AVX512BITALG)
 }
 
 // VPCLMULQDQ indicates support of Carry-Less Multiplication Quadword
 func (c CPUInfo) VPCLMULQDQ() bool {
-	return c.Features&VPCLMULQDQ != 0
+	return c.featureSet.inSet(VPCLMULQDQ)
 }
 
 // AVX512BF16 indicates support of AVX-512 BFLOAT16 Instruction
 func (c CPUInfo) AVX512BF16() bool {
-	return c.Features&AVX512BF16 != 0
+	return c.featureSet.inSet(AVX512BF16)
 }
 
 // AVX512VP2INTERSECT indicates support of AVX-512 Intersect for D/Q
 func (c CPUInfo) AVX512VP2INTERSECT() bool {
-	return c.Features&AVX512VP2INTERSECT != 0
+	return c.featureSet.inSet(AVX512VP2INTERSECT)
 }
 
 // AMXBF16 indicates support of Tile computational operations on BFLOAT16 numbers
 func (c CPUInfo) AMXBF16() bool {
-	return c.AmxFeatures&AMXBF16 != 0
+	return c.featureSet.inSet(AMXBF16)
 }
 
 // AMXTILE indicates support of Tile architecture
 func (c CPUInfo) AMXTILE() bool {
-	return c.AmxFeatures&AMXTILE != 0
+	return c.featureSet.inSet(AMXTILE)
 }
 
 // AMXINT8 indicates support of Tile computational operations on 8-bit integers
 func (c CPUInfo) AMXINT8() bool {
-	return c.AmxFeatures&AMXINT8 != 0
+	return c.featureSet.inSet(AMXINT8)
 }
 
 // MPX indicates support of Intel MPX (Memory Protection Extensions)
 func (c CPUInfo) MPX() bool {
-	return c.Features&MPX != 0
+	return c.featureSet.inSet(MPX)
 }
 
 // ERMS indicates support of Enhanced REP MOVSB/STOSB
 func (c CPUInfo) ERMS() bool {
-	return c.Features&ERMS != 0
+	return c.featureSet.inSet(ERMS)
 }
 
 // RDTSCP Instruction is available.
 func (c CPUInfo) RDTSCP() bool {
-	return c.Features&RDTSCP != 0
+	return c.featureSet.inSet(RDTSCP)
 }
 
 // CX16 indicates if CMPXCHG16B instruction is available.
 func (c CPUInfo) CX16() bool {
-	return c.Features&CX16 != 0
+	return c.featureSet.inSet(CX16)
 }
 
 // TSX is split into HLE (Hardware Lock Elision) and RTM (Restricted Transactional Memory) detection.
 // So TSX simply checks that.
 func (c CPUInfo) TSX() bool {
-	return c.Features&(HLE|RTM) == HLE|RTM
+	return c.featureSet.inSet(HLE) && c.featureSet.inSet(RTM)
 }
 
 // Atom indicates an Atom processor
 func (c CPUInfo) Atom() bool {
-	return c.Features&ATOM != 0
+	return c.featureSet.inSet(ATOM)
 }
 
 // Intel returns true if vendor is recognized as Intel
@@ -654,6 +651,14 @@ func (c CPUInfo) NSC() bool {
 // VIA returns true if vendor is recognized as VIA
 func (c CPUInfo) VIA() bool {
 	return c.VendorID == VIA
+}
+
+func (c CPUInfo) FeatureSet() []string {
+	s := make([]string, 0)
+	for _, f := range c.featureSet.Strings() {
+		s = append(s, f)
+	}
+	return s
 }
 
 // RTCounter returns the 64-bit time-stamp counter
@@ -767,8 +772,8 @@ type Flags uint64
 // ArmFlags contains detected ARM cpu features and characteristics
 type ArmFlags uint64
 
-// AmxFlags contains AMX (x86 Advanced Matrix extension) features
-type AmxFlags uint64
+// FlagSet contains detected cpu features and characteristics in an array of Flags
+type FlagSet []Flags
 
 // String returns a string representation of the detected
 // CPU features.
@@ -776,14 +781,36 @@ func (f Flags) String() string {
 	return strings.Join(f.Strings(), ",")
 }
 
+func (s FlagSet) inSet(offset uint) bool {
+	if len(s) == 0 {
+		return false
+	}
+	return s[offset>>6]&(1<<(offset&63)) != 0
+}
+
+func (s FlagSet) set(offset uint) {
+	if len(s) == 0 {
+		return
+	}
+	s[offset>>6] |= 1 << (offset & 63)
+}
+
 // Strings returns an array of the detected features.
 func (f Flags) Strings() []string {
-	r := make([]string, 0, 20)
-	for i := uint(0); i < 64; i++ {
-		key := Flags(1 << i)
-		val := flagNames[key]
-		if f&key != 0 {
-			r = append(r, val)
+	s := FlagSet{f}
+	return s.Strings()
+}
+
+// Strings returns an array of the detected features for FlagsSet.
+func (s FlagSet) Strings() []string {
+	if len(s) == 0 {
+		return []string{""}
+	}
+	bits := uint(len(s) * 64)
+	r := make([]string, 0, bits)
+	for i := uint(0); i < bits; i++ {
+		if s.inSet(i) {
+			r = append(r, flagNames[Flags(i)])
 		}
 	}
 	return r
@@ -801,25 +828,6 @@ func (f ArmFlags) Strings() []string {
 	for i := uint(0); i < 64; i++ {
 		key := ArmFlags(1 << i)
 		val := flagNamesArm[key]
-		if f&key != 0 {
-			r = append(r, val)
-		}
-	}
-	return r
-}
-
-// String returns a string representation of the detected
-// x86 Advanced Matrix Extensions (AMX) features.
-func (f AmxFlags) String() string {
-	return strings.Join(f.Strings(), ",")
-}
-
-// Strings returns an array of the detected features.
-func (f AmxFlags) Strings() []string {
-	r := make([]string, 0, 20)
-	for i := uint(0); i < 64; i++ {
-		key := AmxFlags(1 << i)
-		val := flagNamesAmx[key]
 		if f&key != 0 {
 			r = append(r, val)
 		}
@@ -1146,71 +1154,72 @@ func hasSGX(available, lc bool) (rval SGXSupport) {
 	return
 }
 
-func support() (Flags, AmxFlags) {
+func support() FlagSet {
 	mfi := maxFunctionID()
 	vend, _ := vendorID()
 	if mfi < 0x1 {
-		return 0, 0
+		return nil
 	}
-	flags := uint64(0)
-	amxFlags := AmxFlags(0)
+
+	fs := make(FlagSet, LASTID/64+1)
+
 	_, _, c, d := cpuid(1)
 	if (d & (1 << 15)) != 0 {
-		flags |= CMOV
+		fs.set(CMOV)
 	}
 	if (d & (1 << 23)) != 0 {
-		flags |= MMX
+		fs.set(MMX)
 	}
 	if (d & (1 << 25)) != 0 {
-		flags |= MMXEXT
+		fs.set(MMXEXT)
 	}
 	if (d & (1 << 25)) != 0 {
-		flags |= SSE
+		fs.set(SSE)
 	}
 	if (d & (1 << 26)) != 0 {
-		flags |= SSE2
+		fs.set(SSE2)
 	}
 	if (c & 1) != 0 {
-		flags |= SSE3
+		fs.set(SSE3)
 	}
 	if (c & (1 << 5)) != 0 {
-		flags |= VMX
+		fs.set(VMX)
 	}
 	if (c & 0x00000200) != 0 {
-		flags |= SSSE3
+		fs.set(SSSE3)
 	}
 	if (c & 0x00080000) != 0 {
-		flags |= SSE4
+		fs.set(SSE4)
 	}
 	if (c & 0x00100000) != 0 {
-		flags |= SSE42
+		fs.set(SSE42)
 	}
 	if (c & (1 << 25)) != 0 {
-		flags |= AESNI
+		fs.set(AESNI)
 	}
 	if (c & (1 << 1)) != 0 {
-		flags |= CLMUL
+		fs.set(CLMUL)
 	}
 	if c&(1<<23) != 0 {
-		flags |= POPCNT
+		fs.set(POPCNT)
 	}
 	if c&(1<<30) != 0 {
-		flags |= RDRAND
+		fs.set(RDRAND)
 	}
 	if c&(1<<29) != 0 {
-		flags |= F16C
+		fs.set(F16C)
 	}
 	if c&(1<<13) != 0 {
-		flags |= CX16
+		fs.set(CX16)
 	}
 	if vend == Intel && (d&(1<<28)) != 0 && mfi >= 4 {
 		if threadsPerCore() > 1 {
-			flags |= HTT
+			fs.set(HTT)
 		}
 	}
 	if vend == AMD && (d&(1<<28)) != 0 && mfi >= 4 {
 		if threadsPerCore() > 1 {
-			flags |= HTT
+			fs.set(HTT)
 		}
 	}
 	// Check XGETBV, OXSAVE and AVX bits
@@ -1218,9 +1227,9 @@ func support() (Flags, AmxFlags) {
 		// Check for OS support
 		eax, _ := xgetbv(0)
 		if (eax & 0x6) == 0x6 {
-			flags |= AVX
+			fs.set(AVX)
 			if (c & 0x00001000) != 0 {
-				flags |= FMA3
+				fs.set(FMA3)
 			}
 		}
 	}
@@ -1229,47 +1238,47 @@ func support() (Flags, AmxFlags) {
 	if mfi >= 7 {
 		_, ebx, ecx, edx := cpuidex(7, 0)
 		eax1, _, _, _ := cpuidex(7, 1)
-		if (flags&AVX) != 0 && (ebx&0x00000020) != 0 {
-			flags |= AVX2
+		if fs.inSet(AVX) && (ebx&0x00000020) != 0 {
+			fs.set(AVX2)
 		}
 		if (ebx & 0x00000008) != 0 {
-			flags |= BMI1
+			fs.set(BMI1)
 			if (ebx & 0x00000100) != 0 {
-				flags |= BMI2
+				fs.set(BMI2)
 			}
 		}
 		if ebx&(1<<2) != 0 {
-			flags |= SGX
+			fs.set(SGX)
 		}
 		if ebx&(1<<4) != 0 {
-			flags |= HLE
+			fs.set(HLE)
 		}
 		if ebx&(1<<9) != 0 {
-			flags |= ERMS
+			fs.set(ERMS)
 		}
 		if ebx&(1<<11) != 0 {
-			flags |= RTM
+			fs.set(RTM)
 		}
 		if ebx&(1<<14) != 0 {
-			flags |= MPX
+			fs.set(MPX)
 		}
 		if ebx&(1<<18) != 0 {
-			flags |= RDSEED
+			fs.set(RDSEED)
 		}
 		if ebx&(1<<19) != 0 {
-			flags |= ADX
+			fs.set(ADX)
 		}
 		if ebx&(1<<29) != 0 {
-			flags |= SHA
+			fs.set(SHA)
 		}
 		if edx&(1<<26) != 0 {
-			flags |= IBPB
+			fs.set(IBPB)
 		}
 		if ecx&(1<<30) != 0 {
-			flags |= SGXLC
+			fs.set(SGXLC)
 		}
 		if edx&(1<<27) != 0 {
-			flags |= STIBP
+			fs.set(STIBP)
 		}
 
 		// Only detect AVX-512 features if XGETBV is supported
@@ -1282,70 +1291,70 @@ func support() (Flags, AmxFlags) {
 			/// and that XCR0[2:1] = ‘11b’ (XMM state and YMM state are enabled by OS).
 			if (eax>>5)&7 == 7 && (eax>>1)&3 == 3 {
 				if ebx&(1<<16) != 0 {
-					flags |= AVX512F
+					fs.set(AVX512F)
 				}
 				if ebx&(1<<17) != 0 {
-					flags |= AVX512DQ
+					fs.set(AVX512DQ)
 				}
 				if ebx&(1<<21) != 0 {
-					flags |= AVX512IFMA
+					fs.set(AVX512IFMA)
 				}
 				if ebx&(1<<26) != 0 {
-					flags |= AVX512PF
+					fs.set(AVX512PF)
 				}
 				if ebx&(1<<27) != 0 {
-					flags |= AVX512ER
+					fs.set(AVX512ER)
 				}
 				if ebx&(1<<28) != 0 {
-					flags |= AVX512CD
+					fs.set(AVX512CD)
 				}
 				if ebx&(1<<30) != 0 {
-					flags |= AVX512BW
+					fs.set(AVX512BW)
 				}
 				if ebx&(1<<31) != 0 {
-					flags |= AVX512VL
+					fs.set(AVX512VL)
 				}
 				// ecx
 				if ecx&(1<<1) != 0 {
-					flags |= AVX512VBMI
+					fs.set(AVX512VBMI)
 				}
 				if ecx&(1<<6) != 0 {
-					flags |= AVX512VBMI2
+					fs.set(AVX512VBMI2)
 				}
 				if ecx&(1<<8) != 0 {
-					flags |= GFNI
+					fs.set(GFNI)
 				}
 				if ecx&(1<<9) != 0 {
-					flags |= VAES
+					fs.set(VAES)
 				}
 				if ecx&(1<<10) != 0 {
-					flags |= VPCLMULQDQ
+					fs.set(VPCLMULQDQ)
 				}
 				if ecx&(1<<11) != 0 {
-					flags |= AVX512VNNI
+					fs.set(AVX512VNNI)
 				}
 				if ecx&(1<<12) != 0 {
-					flags |= AVX512BITALG
+					fs.set(AVX512BITALG)
 				}
 				if ecx&(1<<14) != 0 {
-					flags |= AVX512VPOPCNTDQ
+					fs.set(AVX512VPOPCNTDQ)
 				}
 				// edx
 				if edx&(1<<8) != 0 {
-					flags |= AVX512VP2INTERSECT
+					fs.set(AVX512VP2INTERSECT)
 				}
 				if edx&(1<<22) != 0 {
-					amxFlags |= AMXBF16
+					fs.set(AMXBF16)
 				}
 				if edx&(1<<24) != 0 {
-					amxFlags |= AMXTILE
+					fs.set(AMXTILE)
 				}
 				if edx&(1<<25) != 0 {
-					amxFlags |= AMXINT8
+					fs.set(AMXINT8)
 				}
 				// cpuid eax 07h,ecx=1
 				if eax1&(1<<5) != 0 {
-					flags |= AVX512BF16
+					fs.set(AVX512BF16)
 				}
 			}
 		}
@@ -1354,29 +1363,29 @@ func support() (Flags, AmxFlags) {
 	if maxExtendedFunction() >= 0x80000001 {
 		_, _, c, d := cpuid(0x80000001)
 		if (c & (1 << 5)) != 0 {
-			flags |= LZCNT
-			flags |= POPCNT
+			fs.set(LZCNT)
+			fs.set(POPCNT)
 		}
 		if (d & (1 << 31)) != 0 {
-			flags |= AMD3DNOW
+			fs.set(AMD3DNOW)
 		}
 		if (d & (1 << 30)) != 0 {
-			flags |= AMD3DNOWEXT
+			fs.set(AMD3DNOWEXT)
 		}
 		if (d & (1 << 23)) != 0 {
-			flags |= MMX
+			fs.set(MMX)
 		}
 		if (d & (1 << 22)) != 0 {
-			flags |= MMXEXT
+			fs.set(MMXEXT)
 		}
 		if (c & (1 << 6)) != 0 {
-			flags |= SSE4A
+			fs.set(SSE4A)
 		}
 		if d&(1<<20) != 0 {
-			flags |= NX
+			fs.set(NX)
 		}
 		if d&(1<<27) != 0 {
-			flags |= RDTSCP
+			fs.set(RDTSCP)
 		}
 
 		/* Allow for selectively disabling SSE2 functions on AMD processors
@@ -1387,18 +1396,18 @@ func support() (Flags, AmxFlags) {
 		   so that SSE2 is used unless explicitly disabled by checking
 		   AV_CPU_FLAG_SSE2SLOW. */
 		if vend != Intel &&
-			flags&SSE2 != 0 && (c&0x00000040) == 0 {
-			flags |= SSE2SLOW
+			fs.inSet(SSE2) && (c&0x00000040) == 0 {
+			fs.set(SSE2SLOW)
 		}
 
 		/* XOP and FMA4 use the AVX instruction coding scheme, so they can't be
 		 * used unless the OS has AVX support. */
-		if (flags & AVX) != 0 {
+		if fs.inSet(AVX) {
 			if (c & 0x00000800) != 0 {
-				flags |= XOP
+				fs.set(XOP)
 			}
 			if (c & 0x00010000) != 0 {
-				flags |= FMA4
+				fs.set(FMA4)
 			}
 		}
 
@@ -1408,11 +1417,11 @@ func support() (Flags, AmxFlags) {
 				/* 6/9 (pentium-m "banias"), 6/13 (pentium-m "dothan"), and
 				 * 6/14 (core1 "yonah") theoretically support sse2, but it's
 				 * usually slower than mmx. */
-				if (flags & SSE2) != 0 {
-					flags |= SSE2SLOW
+				if fs.inSet(SSE2) {
+					fs.set(SSE2SLOW)
 				}
-				if (flags & SSE3) != 0 {
-					flags |= SSE3SLOW
+				if fs.inSet(SSE3) {
+					fs.set(SSE3SLOW)
 				}
 			}
 			/* The Atom processor has SSSE3 support, which is useful in many cases,
@@ -1421,11 +1430,12 @@ func support() (Flags, AmxFlags) {
 			 * SSSE3. This flag allows for selectively disabling certain SSSE3
 			 * functions on the Atom. */
 			if family == 6 && model == 28 {
-				flags |= ATOM
+				fs.set(ATOM)
 			}
 		}
 	}
-	return Flags(flags), AmxFlags(amxFlags)
+
+	return fs
 }
 
 func valAsString(values ...uint32) []byte {

--- a/cpuid_test.go
+++ b/cpuid_test.go
@@ -810,7 +810,12 @@ func TestVIA(t *testing.T) {
 
 // Test VM function
 func TestVM(t *testing.T) {
-	t.Log("Vendor ID:", CPU.VM())
+	got := CPU.VM()
+	expected := CPU.featureSet.inSet(HYPERVISOR)
+	if got != expected {
+		t.Fatalf("TestVM: expected %v, got %v", expected, got)
+	}
+	t.Log("TestVM:", got)
 }
 
 // TSX returns true if cpu supports transactional sync extensions.

--- a/cpuid_test.go
+++ b/cpuid_test.go
@@ -5,6 +5,7 @@ package cpuid
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -22,9 +23,8 @@ func TestCPUID(t *testing.T) {
 	t.Log("ThreadsPerCore:", CPU.ThreadsPerCore)
 	t.Log("LogicalCores:", CPU.LogicalCores)
 	t.Log("Family", CPU.Family, "Model:", CPU.Model)
-	t.Log("Features:", CPU.Features)
+	t.Log("Features:", fmt.Sprintf(strings.Join(CPU.FeatureSet(), ",")))
 	t.Log("ARM Features:", CPU.Arm)
-	t.Log("AMX Features:", CPU.AmxFeatures)
 	t.Log("Cacheline bytes:", CPU.CacheLine)
 	t.Log("L1 Instruction Cache:", CPU.Cache.L1I, "bytes")
 	t.Log("L1 Data Cache:", CPU.Cache.L1D, "bytes")
@@ -67,7 +67,7 @@ func Example() {
 	fmt.Println("ThreadsPerCore:", CPU.ThreadsPerCore)
 	fmt.Println("LogicalCores:", CPU.LogicalCores)
 	fmt.Println("Family", CPU.Family, "Model:", CPU.Model)
-	fmt.Println("Features:", CPU.Features)
+	fmt.Println("Features:", fmt.Sprintf(strings.Join(CPU.FeatureSet(), ",")))
 	fmt.Println("Cacheline bytes:", CPU.CacheLine)
 
 	// Test if we have a specific feature:
@@ -93,7 +93,7 @@ func TestBrandNameZero(t *testing.T) {
 // TestCmov tests Cmov() function
 func TestCmov(t *testing.T) {
 	got := CPU.Cmov()
-	expected := CPU.Features&CMOV == CMOV
+	expected := CPU.featureSet.inSet(CMOV)
 	if got != expected {
 		t.Fatalf("Cmov: expected %v, got %v", expected, got)
 	}
@@ -103,7 +103,7 @@ func TestCmov(t *testing.T) {
 // TestAmd3dnow tests Amd3dnow() function
 func TestAmd3dnow(t *testing.T) {
 	got := CPU.Amd3dnow()
-	expected := CPU.Features&AMD3DNOW == AMD3DNOW
+	expected := CPU.featureSet.inSet(AMD3DNOW)
 	if got != expected {
 		t.Fatalf("Amd3dnow: expected %v, got %v", expected, got)
 	}
@@ -113,7 +113,7 @@ func TestAmd3dnow(t *testing.T) {
 // TestAmd3dnowExt tests Amd3dnowExt() function
 func TestAmd3dnowExt(t *testing.T) {
 	got := CPU.Amd3dnowExt()
-	expected := CPU.Features&AMD3DNOWEXT == AMD3DNOWEXT
+	expected := CPU.featureSet.inSet(AMD3DNOWEXT)
 	if got != expected {
 		t.Fatalf("Amd3dnowExt: expected %v, got %v", expected, got)
 	}
@@ -123,7 +123,7 @@ func TestAmd3dnowExt(t *testing.T) {
 // TestVMX tests VMX() function
 func TestVMX(t *testing.T) {
 	got := CPU.VMX()
-	expected := CPU.Features&VMX == VMX
+	expected := CPU.featureSet.inSet(VMX)
 	if got != expected {
 		t.Fatalf("VMX: expected %v, got %v", expected, got)
 	}
@@ -133,7 +133,7 @@ func TestVMX(t *testing.T) {
 // TestMMX tests MMX() function
 func TestMMX(t *testing.T) {
 	got := CPU.MMX()
-	expected := CPU.Features&MMX == MMX
+	expected := CPU.featureSet.inSet(MMX)
 	if got != expected {
 		t.Fatalf("MMX: expected %v, got %v", expected, got)
 	}
@@ -143,7 +143,7 @@ func TestMMX(t *testing.T) {
 // TestMMXext tests MMXext() function
 func TestMMXext(t *testing.T) {
 	got := CPU.MMXExt()
-	expected := CPU.Features&MMXEXT == MMXEXT
+	expected := CPU.featureSet.inSet(MMXEXT)
 	if got != expected {
 		t.Fatalf("MMXExt: expected %v, got %v", expected, got)
 	}
@@ -153,7 +153,7 @@ func TestMMXext(t *testing.T) {
 // TestSSE tests SSE() function
 func TestSSE(t *testing.T) {
 	got := CPU.SSE()
-	expected := CPU.Features&SSE == SSE
+	expected := CPU.featureSet.inSet(SSE)
 	if got != expected {
 		t.Fatalf("SSE: expected %v, got %v", expected, got)
 	}
@@ -163,7 +163,7 @@ func TestSSE(t *testing.T) {
 // TestSSE2 tests SSE2() function
 func TestSSE2(t *testing.T) {
 	got := CPU.SSE2()
-	expected := CPU.Features&SSE2 == SSE2
+	expected := CPU.featureSet.inSet(SSE2)
 	if got != expected {
 		t.Fatalf("SSE2: expected %v, got %v", expected, got)
 	}
@@ -173,7 +173,7 @@ func TestSSE2(t *testing.T) {
 // TestSSE3 tests SSE3() function
 func TestSSE3(t *testing.T) {
 	got := CPU.SSE3()
-	expected := CPU.Features&SSE3 == SSE3
+	expected := CPU.featureSet.inSet(SSE3)
 	if got != expected {
 		t.Fatalf("SSE3: expected %v, got %v", expected, got)
 	}
@@ -183,7 +183,7 @@ func TestSSE3(t *testing.T) {
 // TestSSSE3 tests SSSE3() function
 func TestSSSE3(t *testing.T) {
 	got := CPU.SSSE3()
-	expected := CPU.Features&SSSE3 == SSSE3
+	expected := CPU.featureSet.inSet(SSSE3)
 	if got != expected {
 		t.Fatalf("SSSE3: expected %v, got %v", expected, got)
 	}
@@ -193,7 +193,7 @@ func TestSSSE3(t *testing.T) {
 // TestSSE4 tests SSE4() function
 func TestSSE4(t *testing.T) {
 	got := CPU.SSE4()
-	expected := CPU.Features&SSE4 == SSE4
+	expected := CPU.featureSet.inSet(SSE4)
 	if got != expected {
 		t.Fatalf("SSE4: expected %v, got %v", expected, got)
 	}
@@ -203,7 +203,7 @@ func TestSSE4(t *testing.T) {
 // TestSSE42 tests SSE42() function
 func TestSSE42(t *testing.T) {
 	got := CPU.SSE42()
-	expected := CPU.Features&SSE42 == SSE42
+	expected := CPU.featureSet.inSet(SSE42)
 	if got != expected {
 		t.Fatalf("SSE42: expected %v, got %v", expected, got)
 	}
@@ -213,7 +213,7 @@ func TestSSE42(t *testing.T) {
 // TestAVX tests AVX() function
 func TestAVX(t *testing.T) {
 	got := CPU.AVX()
-	expected := CPU.Features&AVX == AVX
+	expected := CPU.featureSet.inSet(AVX)
 	if got != expected {
 		t.Fatalf("AVX: expected %v, got %v", expected, got)
 	}
@@ -223,7 +223,7 @@ func TestAVX(t *testing.T) {
 // TestAVX2 tests AVX2() function
 func TestAVX2(t *testing.T) {
 	got := CPU.AVX2()
-	expected := CPU.Features&AVX2 == AVX2
+	expected := CPU.featureSet.inSet(AVX2)
 	if got != expected {
 		t.Fatalf("AVX2: expected %v, got %v", expected, got)
 	}
@@ -233,7 +233,7 @@ func TestAVX2(t *testing.T) {
 // TestFMA3 tests FMA3() function
 func TestFMA3(t *testing.T) {
 	got := CPU.FMA3()
-	expected := CPU.Features&FMA3 == FMA3
+	expected := CPU.featureSet.inSet(FMA3)
 	if got != expected {
 		t.Fatalf("FMA3: expected %v, got %v", expected, got)
 	}
@@ -243,7 +243,7 @@ func TestFMA3(t *testing.T) {
 // TestFMA4 tests FMA4() function
 func TestFMA4(t *testing.T) {
 	got := CPU.FMA4()
-	expected := CPU.Features&FMA4 == FMA4
+	expected := CPU.featureSet.inSet(FMA4)
 	if got != expected {
 		t.Fatalf("FMA4: expected %v, got %v", expected, got)
 	}
@@ -253,7 +253,7 @@ func TestFMA4(t *testing.T) {
 // TestXOP tests XOP() function
 func TestXOP(t *testing.T) {
 	got := CPU.XOP()
-	expected := CPU.Features&XOP == XOP
+	expected := CPU.featureSet.inSet(XOP)
 	if got != expected {
 		t.Fatalf("XOP: expected %v, got %v", expected, got)
 	}
@@ -263,7 +263,7 @@ func TestXOP(t *testing.T) {
 // TestF16C tests F16C() function
 func TestF16C(t *testing.T) {
 	got := CPU.F16C()
-	expected := CPU.Features&F16C == F16C
+	expected := CPU.featureSet.inSet(F16C)
 	if got != expected {
 		t.Fatalf("F16C: expected %v, got %v", expected, got)
 	}
@@ -273,7 +273,7 @@ func TestF16C(t *testing.T) {
 // TestCX16 tests CX16() function
 func TestCX16(t *testing.T) {
 	got := CPU.CX16()
-	expected := CPU.Features&CX16 == CX16
+	expected := CPU.featureSet.inSet(CX16)
 	if got != expected {
 		t.Fatalf("CX16: expected %v, got %v", expected, got)
 	}
@@ -283,7 +283,7 @@ func TestCX16(t *testing.T) {
 // TestSGX tests SGX detection
 func TestSGX(t *testing.T) {
 	got := CPU.SGX.Available
-	expected := CPU.Features&SGX == SGX
+	expected := CPU.featureSet.inSet(SGX)
 	if got != expected {
 		t.Fatalf("SGX: expected %v, got %v", expected, got)
 	}
@@ -306,7 +306,7 @@ func TestSGX(t *testing.T) {
 // TestSGXLC tests SGX Launch Control detection
 func TestSGXLC(t *testing.T) {
 	got := CPU.SGX.LaunchControl
-	expected := CPU.Features&SGXLC == SGXLC
+	expected := CPU.featureSet.inSet(SGXLC)
 	if got != expected {
 		t.Fatalf("SGX: expected %v, got %v", expected, got)
 	}
@@ -316,7 +316,7 @@ func TestSGXLC(t *testing.T) {
 // TestBMI1 tests BMI1() function
 func TestBMI1(t *testing.T) {
 	got := CPU.BMI1()
-	expected := CPU.Features&BMI1 == BMI1
+	expected := CPU.featureSet.inSet(BMI1)
 	if got != expected {
 		t.Fatalf("BMI1: expected %v, got %v", expected, got)
 	}
@@ -326,7 +326,7 @@ func TestBMI1(t *testing.T) {
 // TestBMI2 tests BMI2() function
 func TestBMI2(t *testing.T) {
 	got := CPU.BMI2()
-	expected := CPU.Features&BMI2 == BMI2
+	expected := CPU.featureSet.inSet(BMI2)
 	if got != expected {
 		t.Fatalf("BMI2: expected %v, got %v", expected, got)
 	}
@@ -336,7 +336,7 @@ func TestBMI2(t *testing.T) {
 // TestTBM tests TBM() function
 func TestTBM(t *testing.T) {
 	got := CPU.TBM()
-	expected := CPU.Features&TBM == TBM
+	expected := CPU.featureSet.inSet(TBM)
 	if got != expected {
 		t.Fatalf("TBM: expected %v, got %v", expected, got)
 	}
@@ -346,7 +346,7 @@ func TestTBM(t *testing.T) {
 // TestLzcnt tests Lzcnt() function
 func TestLzcnt(t *testing.T) {
 	got := CPU.Lzcnt()
-	expected := CPU.Features&LZCNT == LZCNT
+	expected := CPU.featureSet.inSet(LZCNT)
 	if got != expected {
 		t.Fatalf("Lzcnt: expected %v, got %v", expected, got)
 	}
@@ -356,7 +356,7 @@ func TestLzcnt(t *testing.T) {
 // TestLzcnt tests Lzcnt() function
 func TestPopcnt(t *testing.T) {
 	got := CPU.Popcnt()
-	expected := CPU.Features&POPCNT == POPCNT
+	expected := CPU.featureSet.inSet(POPCNT)
 	if got != expected {
 		t.Fatalf("Popcnt: expected %v, got %v", expected, got)
 	}
@@ -366,7 +366,7 @@ func TestPopcnt(t *testing.T) {
 // TestAesNi tests AesNi() function
 func TestAesNi(t *testing.T) {
 	got := CPU.AesNi()
-	expected := CPU.Features&AESNI == AESNI
+	expected := CPU.featureSet.inSet(AESNI)
 	if got != expected {
 		t.Fatalf("AesNi: expected %v, got %v", expected, got)
 	}
@@ -376,7 +376,7 @@ func TestAesNi(t *testing.T) {
 // TestHTT tests HTT() function
 func TestHTT(t *testing.T) {
 	got := CPU.HTT()
-	expected := CPU.Features&HTT == HTT
+	expected := CPU.featureSet.inSet(HTT)
 	if got != expected {
 		t.Fatalf("HTT: expected %v, got %v", expected, got)
 	}
@@ -386,7 +386,7 @@ func TestHTT(t *testing.T) {
 // TestClmul tests Clmul() function
 func TestClmul(t *testing.T) {
 	got := CPU.Clmul()
-	expected := CPU.Features&CLMUL == CLMUL
+	expected := CPU.featureSet.inSet(CLMUL)
 	if got != expected {
 		t.Fatalf("Clmul: expected %v, got %v", expected, got)
 	}
@@ -396,7 +396,7 @@ func TestClmul(t *testing.T) {
 // TestSSE2Slow tests SSE2Slow() function
 func TestSSE2Slow(t *testing.T) {
 	got := CPU.SSE2Slow()
-	expected := CPU.Features&SSE2SLOW == SSE2SLOW
+	expected := CPU.featureSet.inSet(SSE2SLOW)
 	if got != expected {
 		t.Fatalf("SSE2Slow: expected %v, got %v", expected, got)
 	}
@@ -406,7 +406,7 @@ func TestSSE2Slow(t *testing.T) {
 // TestSSE3Slow tests SSE3slow() function
 func TestSSE3Slow(t *testing.T) {
 	got := CPU.SSE3Slow()
-	expected := CPU.Features&SSE3SLOW == SSE3SLOW
+	expected := CPU.featureSet.inSet(SSE3SLOW)
 	if got != expected {
 		t.Fatalf("SSE3slow: expected %v, got %v", expected, got)
 	}
@@ -416,7 +416,7 @@ func TestSSE3Slow(t *testing.T) {
 // TestAtom tests Atom() function
 func TestAtom(t *testing.T) {
 	got := CPU.Atom()
-	expected := CPU.Features&ATOM == ATOM
+	expected := CPU.featureSet.inSet(ATOM)
 	if got != expected {
 		t.Fatalf("Atom: expected %v, got %v", expected, got)
 	}
@@ -426,7 +426,7 @@ func TestAtom(t *testing.T) {
 // TestNX tests NX() function (NX (No-Execute) bit)
 func TestNX(t *testing.T) {
 	got := CPU.NX()
-	expected := CPU.Features&NX == NX
+	expected := CPU.featureSet.inSet(NX)
 	if got != expected {
 		t.Fatalf("NX: expected %v, got %v", expected, got)
 	}
@@ -436,7 +436,7 @@ func TestNX(t *testing.T) {
 // TestSSE4A tests SSE4A() function (AMD Barcelona microarchitecture SSE4a instructions)
 func TestSSE4A(t *testing.T) {
 	got := CPU.SSE4A()
-	expected := CPU.Features&SSE4A == SSE4A
+	expected := CPU.featureSet.inSet(SSE4A)
 	if got != expected {
 		t.Fatalf("SSE4A: expected %v, got %v", expected, got)
 	}
@@ -446,7 +446,7 @@ func TestSSE4A(t *testing.T) {
 // TestHLE tests HLE() function (Hardware Lock Elision)
 func TestHLE(t *testing.T) {
 	got := CPU.HLE()
-	expected := CPU.Features&HLE == HLE
+	expected := CPU.featureSet.inSet(HLE)
 	if got != expected {
 		t.Fatalf("HLE: expected %v, got %v", expected, got)
 	}
@@ -456,7 +456,7 @@ func TestHLE(t *testing.T) {
 // TestRTM tests RTM() function (Restricted Transactional Memory)
 func TestRTM(t *testing.T) {
 	got := CPU.RTM()
-	expected := CPU.Features&RTM == RTM
+	expected := CPU.featureSet.inSet(RTM)
 	if got != expected {
 		t.Fatalf("RTM: expected %v, got %v", expected, got)
 	}
@@ -466,7 +466,7 @@ func TestRTM(t *testing.T) {
 // TestRdrand tests RDRAND() function (RDRAND instruction is available)
 func TestRdrand(t *testing.T) {
 	got := CPU.Rdrand()
-	expected := CPU.Features&RDRAND == RDRAND
+	expected := CPU.featureSet.inSet(RDRAND)
 	if got != expected {
 		t.Fatalf("Rdrand: expected %v, got %v", expected, got)
 	}
@@ -476,7 +476,7 @@ func TestRdrand(t *testing.T) {
 // TestRdseed tests RDSEED() function (RDSEED instruction is available)
 func TestRdseed(t *testing.T) {
 	got := CPU.Rdseed()
-	expected := CPU.Features&RDSEED == RDSEED
+	expected := CPU.featureSet.inSet(RDSEED)
 	if got != expected {
 		t.Fatalf("Rdseed: expected %v, got %v", expected, got)
 	}
@@ -486,7 +486,7 @@ func TestRdseed(t *testing.T) {
 // TestADX tests ADX() function (Intel ADX (Multi-Precision Add-Carry Instruction Extensions))
 func TestADX(t *testing.T) {
 	got := CPU.ADX()
-	expected := CPU.Features&ADX == ADX
+	expected := CPU.featureSet.inSet(ADX)
 	if got != expected {
 		t.Fatalf("ADX: expected %v, got %v", expected, got)
 	}
@@ -496,7 +496,7 @@ func TestADX(t *testing.T) {
 // TestSHA tests SHA() function (Intel SHA Extensions)
 func TestSHA(t *testing.T) {
 	got := CPU.SHA()
-	expected := CPU.Features&SHA == SHA
+	expected := CPU.featureSet.inSet(SHA)
 	if got != expected {
 		t.Fatalf("SHA: expected %v, got %v", expected, got)
 	}
@@ -506,7 +506,7 @@ func TestSHA(t *testing.T) {
 // TestAVX512F tests AVX512F() function (AVX-512 Foundation)
 func TestAVX512F(t *testing.T) {
 	got := CPU.AVX512F()
-	expected := CPU.Features&AVX512F == AVX512F
+	expected := CPU.featureSet.inSet(AVX512F)
 	if got != expected {
 		t.Fatalf("AVX512F: expected %v, got %v", expected, got)
 	}
@@ -516,7 +516,7 @@ func TestAVX512F(t *testing.T) {
 // TestAVX512DQ tests AVX512DQ() function (AVX-512 Doubleword and Quadword Instructions)
 func TestAVX512DQ(t *testing.T) {
 	got := CPU.AVX512DQ()
-	expected := CPU.Features&AVX512DQ == AVX512DQ
+	expected := CPU.featureSet.inSet(AVX512DQ)
 	if got != expected {
 		t.Fatalf("AVX512DQ: expected %v, got %v", expected, got)
 	}
@@ -526,7 +526,7 @@ func TestAVX512DQ(t *testing.T) {
 // TestAVX512IFMA tests AVX512IFMA() function (AVX-512 Integer Fused Multiply-Add Instructions)
 func TestAVX512IFMA(t *testing.T) {
 	got := CPU.AVX512IFMA()
-	expected := CPU.Features&AVX512IFMA == AVX512IFMA
+	expected := CPU.featureSet.inSet(AVX512IFMA)
 	if got != expected {
 		t.Fatalf("AVX512IFMA: expected %v, got %v", expected, got)
 	}
@@ -536,7 +536,7 @@ func TestAVX512IFMA(t *testing.T) {
 // TestAVX512PF tests AVX512PF() function (AVX-512 Prefetch Instructions)
 func TestAVX512PF(t *testing.T) {
 	got := CPU.AVX512PF()
-	expected := CPU.Features&AVX512PF == AVX512PF
+	expected := CPU.featureSet.inSet(AVX512PF)
 	if got != expected {
 		t.Fatalf("AVX512PF: expected %v, got %v", expected, got)
 	}
@@ -546,7 +546,7 @@ func TestAVX512PF(t *testing.T) {
 // TestAVX512ER tests AVX512ER() function (AVX-512 Exponential and Reciprocal Instructions)
 func TestAVX512ER(t *testing.T) {
 	got := CPU.AVX512ER()
-	expected := CPU.Features&AVX512ER == AVX512ER
+	expected := CPU.featureSet.inSet(AVX512ER)
 	if got != expected {
 		t.Fatalf("AVX512ER: expected %v, got %v", expected, got)
 	}
@@ -556,7 +556,7 @@ func TestAVX512ER(t *testing.T) {
 // TestAVX512CD tests AVX512CD() function (AVX-512 Conflict Detection Instructions)
 func TestAVX512CD(t *testing.T) {
 	got := CPU.AVX512CD()
-	expected := CPU.Features&AVX512CD == AVX512CD
+	expected := CPU.featureSet.inSet(AVX512CD)
 	if got != expected {
 		t.Fatalf("AVX512CD: expected %v, got %v", expected, got)
 	}
@@ -566,7 +566,7 @@ func TestAVX512CD(t *testing.T) {
 // TestAVX512BW tests AVX512BW() function (AVX-512 Byte and Word Instructions)
 func TestAVX512BW(t *testing.T) {
 	got := CPU.AVX512BW()
-	expected := CPU.Features&AVX512BW == AVX512BW
+	expected := CPU.featureSet.inSet(AVX512BW)
 	if got != expected {
 		t.Fatalf("AVX512BW: expected %v, got %v", expected, got)
 	}
@@ -576,7 +576,7 @@ func TestAVX512BW(t *testing.T) {
 // TestAVX512VL tests AVX512VL() function (AVX-512 Vector Length Extensions)
 func TestAVX512VL(t *testing.T) {
 	got := CPU.AVX512VL()
-	expected := CPU.Features&AVX512VL == AVX512VL
+	expected := CPU.featureSet.inSet(AVX512VL)
 	if got != expected {
 		t.Fatalf("AVX512VL: expected %v, got %v", expected, got)
 	}
@@ -586,7 +586,7 @@ func TestAVX512VL(t *testing.T) {
 // TestAVX512VBMI tests AVX512VBMI() function (AVX-512 Vector Bit Manipulation Instructions)
 func TestAVX512VBMI(t *testing.T) {
 	got := CPU.AVX512VBMI()
-	expected := CPU.Features&AVX512VBMI == AVX512VBMI
+	expected := CPU.featureSet.inSet(AVX512VBMI)
 	if got != expected {
 		t.Fatalf("AVX512VBMI: expected %v, got %v", expected, got)
 	}
@@ -596,7 +596,7 @@ func TestAVX512VBMI(t *testing.T) {
 // TestAVX512_VBMI2 tests AVX512VBMI2 function (AVX-512 Vector Bit Manipulation Instructions, Version 2)
 func TestAVX512_VBMI2(t *testing.T) {
 	got := CPU.AVX512VBMI2()
-	expected := CPU.Features&AVX512VBMI2 == AVX512VBMI2
+	expected := CPU.featureSet.inSet(AVX512VBMI2)
 	if got != expected {
 		t.Fatalf("AVX512VBMI2: expected %v, got %v", expected, got)
 	}
@@ -606,7 +606,7 @@ func TestAVX512_VBMI2(t *testing.T) {
 // TestAVX512_VNNI tests AVX512VNNI() function (AVX-512 Vector Neural Network Instructions)
 func TestAVX512_VNNI(t *testing.T) {
 	got := CPU.AVX512VNNI()
-	expected := CPU.Features&AVX512VNNI == AVX512VNNI
+	expected := CPU.featureSet.inSet(AVX512VNNI)
 	if got != expected {
 		t.Fatalf("AVX512VNNI: expected %v, got %v", expected, got)
 	}
@@ -616,7 +616,7 @@ func TestAVX512_VNNI(t *testing.T) {
 // TestAVX512_VPOPCNTDQ tests AVX512VPOPCNTDQ() function (AVX-512 Vector Population Count Doubleword and Quadword)
 func TestAVX512_VPOPCNTDQ(t *testing.T) {
 	got := CPU.AVX512VPOPCNTDQ()
-	expected := CPU.Features&AVX512VPOPCNTDQ == AVX512VPOPCNTDQ
+	expected := CPU.featureSet.inSet(AVX512VPOPCNTDQ)
 	if got != expected {
 		t.Fatalf("AVX512VPOPCNTDQ: expected %v, got %v", expected, got)
 	}
@@ -626,7 +626,7 @@ func TestAVX512_VPOPCNTDQ(t *testing.T) {
 // TestGFNI tests GFNI() function (Galois Field New Instructions)
 func TestGFNI(t *testing.T) {
 	got := CPU.GFNI()
-	expected := CPU.Features&GFNI == GFNI
+	expected := CPU.featureSet.inSet(GFNI)
 	if got != expected {
 		t.Fatalf("GFNI: expected %v, got %v", expected, got)
 	}
@@ -636,7 +636,7 @@ func TestGFNI(t *testing.T) {
 // TestVAES tests VAES() function (Vector AES)
 func TestVAES(t *testing.T) {
 	got := CPU.VAES()
-	expected := CPU.Features&VAES == VAES
+	expected := CPU.featureSet.inSet(VAES)
 	if got != expected {
 		t.Fatalf("VAES: expected %v, got %v", expected, got)
 	}
@@ -646,7 +646,7 @@ func TestVAES(t *testing.T) {
 // TestAVX512_BITALG tests AVX512BITALG() function (AVX-512 Bit Algorithms)
 func TestAVX512_BITALG(t *testing.T) {
 	got := CPU.AVX512BITALG()
-	expected := CPU.Features&AVX512BITALG == AVX512BITALG
+	expected := CPU.featureSet.inSet(AVX512BITALG)
 	if got != expected {
 		t.Fatalf("AVX512BITALG: expected %v, got %v", expected, got)
 	}
@@ -656,7 +656,7 @@ func TestAVX512_BITALG(t *testing.T) {
 // TestVPCLMULQDQ tests VPCLMULQDQ() function (Carry-Less Multiplication Quadword)
 func TestVPCLMULQDQ(t *testing.T) {
 	got := CPU.VPCLMULQDQ()
-	expected := CPU.Features&VPCLMULQDQ == VPCLMULQDQ
+	expected := CPU.featureSet.inSet(VPCLMULQDQ)
 	if got != expected {
 		t.Fatalf("VPCLMULQDQ: expected %v, got %v", expected, got)
 	}
@@ -666,7 +666,7 @@ func TestVPCLMULQDQ(t *testing.T) {
 // TestAVX512_BF16 tests AVX512BF16() function (AVX-512 BFLOAT16 Instructions)
 func TestAVX512_BF16(t *testing.T) {
 	got := CPU.AVX512BF16()
-	expected := CPU.Features&AVX512BF16 == AVX512BF16
+	expected := CPU.featureSet.inSet(AVX512BF16)
 	if got != expected {
 		t.Fatalf("AVX512BF16: expected %v, got %v", expected, got)
 	}
@@ -676,7 +676,7 @@ func TestAVX512_BF16(t *testing.T) {
 // TestAVX512_VP2INTERSECT tests AVX512VP2INTERSECT() function (AVX-512 Intersect for D/Q)
 func TestAVX512_VP2INTERSECT(t *testing.T) {
 	got := CPU.AVX512VP2INTERSECT()
-	expected := CPU.Features&AVX512VP2INTERSECT == AVX512VP2INTERSECT
+	expected := CPU.featureSet.inSet(AVX512VP2INTERSECT)
 	if got != expected {
 		t.Fatalf("AVX512VP2INTERSECT: expected %v, got %v", expected, got)
 	}
@@ -686,7 +686,7 @@ func TestAVX512_VP2INTERSECT(t *testing.T) {
 // TestAMXBF16 tests AMXBF16() function (Tile computational operations on BFLOAT16 numbers)
 func TestAMXBF16(t *testing.T) {
 	got := CPU.AMXBF16()
-	expected := CPU.AmxFeatures&AMXBF16 == AMXBF16
+	expected := CPU.featureSet.inSet(AMXBF16)
 	if got != expected {
 		t.Fatalf("AMXBF16: expected %v, got %v", expected, got)
 	}
@@ -696,7 +696,7 @@ func TestAMXBF16(t *testing.T) {
 // TestAMXTILE tests AMXTILE() function (Tile architecture)
 func TestAMXTILE(t *testing.T) {
 	got := CPU.AMXTILE()
-	expected := CPU.AmxFeatures&AMXTILE == AMXTILE
+	expected := CPU.featureSet.inSet(AMXTILE)
 	if got != expected {
 		t.Fatalf("AMXTILE: expected %v, got %v", expected, got)
 	}
@@ -706,7 +706,7 @@ func TestAMXTILE(t *testing.T) {
 // TestAMXINT8 tests AMXINT8() function (Tile computational operations on 8-bit integers)
 func TestAMXINT8(t *testing.T) {
 	got := CPU.AMXINT8()
-	expected := CPU.AmxFeatures&AMXINT8 == AMXINT8
+	expected := CPU.featureSet.inSet(AMXINT8)
 	if got != expected {
 		t.Fatalf("AMXINT8: expected %v, got %v", expected, got)
 	}
@@ -716,7 +716,7 @@ func TestAMXINT8(t *testing.T) {
 // TestMPX tests MPX() function (Intel MPX (Memory Protection Extensions))
 func TestMPX(t *testing.T) {
 	got := CPU.MPX()
-	expected := CPU.Features&MPX == MPX
+	expected := CPU.featureSet.inSet(MPX)
 	if got != expected {
 		t.Fatalf("MPX: expected %v, got %v", expected, got)
 	}
@@ -726,23 +726,21 @@ func TestMPX(t *testing.T) {
 // TestERMS tests ERMS() function (Enhanced REP MOVSB/STOSB)
 func TestERMS(t *testing.T) {
 	got := CPU.ERMS()
-	expected := CPU.Features&ERMS == ERMS
+	expected := CPU.featureSet.inSet(ERMS)
 	if got != expected {
 		t.Fatalf("ERMS: expected %v, got %v", expected, got)
 	}
 	t.Log("ERMS Support:", got)
 }
 
-// TestAmxStrings tests AmxFlags.Strings()
-func TestAmxStrings(t *testing.T) {
-	af := AmxFlags(0)
-	af |= (AMXBF16 | AMXTILE | AMXINT8)
-	got := af.Strings()
-	expected := []string{"AMXBF16", "AMXTILE", "AMXINT8"}
-	if !reflect.DeepEqual(got, expected) {
-		t.Fatalf("AmxFlags Strings: expected %v, got %v", expected, got)
+// Tests that the new FeatureSet() is compatible with the legacy
+// Features' Stringer.
+func TestX86FeaturesCompat(t *testing.T) {
+	s := strings.Split(fmt.Sprint(CPU.Features), ",")
+	f := CPU.FeatureSet()
+	if !reflect.DeepEqual(s, f[:len(s)]) {
+		t.Fatalf("Legacy Features (Stringer) differs from FeatureSet():\nexpected: %v\nbut got:  %v", s, f[:len(s)])
 	}
-	t.Log("AmxFlags Strings:", got)
 }
 
 // TestVendor writes the detected vendor. Will be 0 if unknown

--- a/detect_intel.go
+++ b/detect_intel.go
@@ -22,8 +22,11 @@ func addInfo(c *CPUInfo) {
 	c.BrandName = brandName()
 	c.CacheLine = cacheLine()
 	c.Family, c.Model = familyModel()
-	c.Features, c.AmxFeatures = support()
-	c.SGX = hasSGX(c.Features&SGX != 0, c.Features&SGXLC != 0)
+	c.featureSet = support()
+	if c.featureSet != nil {
+		c.Features = c.featureSet[0]
+	}
+	c.SGX = hasSGX(c.featureSet.inSet(SGX), c.featureSet.inSet(SGXLC))
 	c.ThreadsPerCore = threadsPerCore()
 	c.LogicalCores = logicalCores()
 	c.PhysicalCores = physicalCores()

--- a/mockcpu_test.go
+++ b/mockcpu_test.go
@@ -185,7 +185,7 @@ func TestMocks(t *testing.T) {
 		t.Log("ThreadsPerCore:", CPU.ThreadsPerCore)
 		t.Log("LogicalCores:", CPU.LogicalCores)
 		t.Log("Family", CPU.Family, "Model:", CPU.Model)
-		t.Log("Features:", CPU.Features)
+		t.Log("Features:", fmt.Sprintf(strings.Join(CPU.FeatureSet(), ",")))
 		t.Log("Cacheline bytes:", CPU.CacheLine)
 		t.Log("L1 Instruction Cache:", CPU.Cache.L1I, "bytes")
 		t.Log("L1 Data Cache:", CPU.Cache.L1D, "bytes")


### PR DESCRIPTION
This change deprecates CPU.Features due to a limitation of only
64 feature bits available when using Flags type (uint64).

The new method introduces a FlagSet with flag names as map keys. The set
values are empty structs which, in Go, consume zero bytes.

The proposal is to start adding post-Icelake new features to FlagSet.

The new model makes it possible to combine Arm Flags too (`flagNames` and `flagNamesArm`
are no longer needed)

TODO: more testing and discussion

/cc @askervin  