### PR TITLE
Detect ARM64 affinity cores

### DIFF
--- a/cpuid.go
+++ b/cpuid.go
@@ -38,6 +38,19 @@ const (
 	SiS
 	RDC
 
+	Ampere
+	ARM
+	Broadcom
+	Cavium
+	DEC
+	Fujitsu
+	Infineon
+	Motorola
+	NVIDIA
+	AMCC
+	Qualcomm
+	Marvell
+
 	lastVendor
 )
 

--- a/detect_arm64.go
+++ b/detect_arm64.go
@@ -26,12 +26,13 @@ func addInfo(c *CPUInfo, safe bool) {
 	}
 
 	// ARM64 disabled since it may crash if interrupt is not intercepted by OS.
-	if safe && runtime.GOOS != "freebsd" {
+	if safe && !c.Supports(ARMCPUID) && runtime.GOOS != "freebsd" {
 		return
 	}
-	// 	midr := getMidr()
+	midr := getMidr()
 
 	// MIDR_EL1 - Main ID Register
+	// https://developer.arm.com/docs/ddi0595/h/aarch64-system-registers/midr_el1
 	//  x--------------------------------------------------x
 	//  | Name                         |  bits   | visible |
 	//  |--------------------------------------------------|
@@ -46,11 +47,70 @@ func addInfo(c *CPUInfo, safe bool) {
 	//  | Revision                     | [3-0]   |    y    |
 	//  x--------------------------------------------------x
 
-	// 	fmt.Printf(" implementer:  0x%02x\n", (midr>>24)&0xff)
-	// 	fmt.Printf("     variant:   0x%01x\n", (midr>>20)&0xf)
-	// 	fmt.Printf("architecture:   0x%01x\n", (midr>>16)&0xf)
-	// 	fmt.Printf("    part num: 0x%03x\n", (midr>>4)&0xfff)
-	// 	fmt.Printf("    revision:   0x%01x\n", (midr>>0)&0xf)
+	switch (midr >> 24) & 0xff {
+	case 0xC0:
+		c.VendorString = "Ampere Computing"
+		c.VendorID = Ampere
+	case 0x41:
+		c.VendorString = "Arm Limited"
+		c.VendorID = ARM
+	case 0x42:
+		c.VendorString = "Broadcom Corporation"
+		c.VendorID = Broadcom
+	case 0x43:
+		c.VendorString = "Cavium Inc"
+		c.VendorID = Cavium
+	case 0x44:
+		c.VendorString = "Digital Equipment Corporation"
+		c.VendorID = DEC
+	case 0x46:
+		c.VendorString = "Fujitsu Ltd"
+		c.VendorID = Fujitsu
+	case 0x49:
+		c.VendorString = "Infineon Technologies AG"
+		c.VendorID = Infineon
+	case 0x4D:
+		c.VendorString = "Motorola or Freescale Semiconductor Inc"
+		c.VendorID = Motorola
+	case 0x4E:
+		c.VendorString = "NVIDIA Corporation"
+		c.VendorID = NVIDIA
+	case 0x50:
+		c.VendorString = "Applied Micro Circuits Corporation"
+		c.VendorID = AMCC
+	case 0x51:
+		c.VendorString = "Qualcomm Inc"
+		c.VendorID = Qualcomm
+	case 0x56:
+		c.VendorString = "Marvell International Ltd"
+		c.VendorID = Marvell
+	case 0x69:
+		c.VendorString = "Intel Corporation"
+		c.VendorID = Intel
+	}
+
+	// Lower 4 bits: Architecture
+	// Architecture	Meaning
+	// 0b0001		Armv4.
+	// 0b0010		Armv4T.
+	// 0b0011		Armv5 (obsolete).
+	// 0b0100		Armv5T.
+	// 0b0101		Armv5TE.
+	// 0b0110		Armv5TEJ.
+	// 0b0111		Armv6.
+	// 0b1111		Architectural features are individually identified in the ID_* registers, see 'ID registers'.
+	// Upper 4 bit: Variant
+	// An IMPLEMENTATION DEFINED variant number.
+	// Typically, this field is used to distinguish between different product variants, or major revisions of a product.
+	c.Family = int(midr>>16) & 0xff
+
+	// PartNum, bits [15:4]
+	// An IMPLEMENTATION DEFINED primary part number for the device.
+	// On processors implemented by Arm, if the top four bits of the primary
+	// part number are 0x0 or 0x7, the variant and architecture are encoded differently.
+	// Revision, bits [3:0]
+	// An IMPLEMENTATION DEFINED revision number for the device.
+	c.Model = int(midr) & 0xffff
 
 	procFeatures := getProcFeatures()
 

--- a/detect_arm64.go
+++ b/detect_arm64.go
@@ -20,10 +20,7 @@ func initCPU() {
 func addInfo(c *CPUInfo, safe bool) {
 	// Seems to be safe to assume on ARM64
 	c.CacheLine = 64
-	if detectOS(c) {
-		// We could detect values from OS, fine.
-		return
-	}
+	detectOS(c)
 
 	// ARM64 disabled since it may crash if interrupt is not intercepted by OS.
 	if safe && !c.Supports(ARMCPUID) && runtime.GOOS != "freebsd" {

--- a/featureid_string.go
+++ b/featureid_string.go
@@ -146,12 +146,24 @@ func _() {
 	_ = x[Hygon-11]
 	_ = x[SiS-12]
 	_ = x[RDC-13]
-	_ = x[lastVendor-14]
+	_ = x[Ampere-14]
+	_ = x[ARM-15]
+	_ = x[Broadcom-16]
+	_ = x[Cavium-17]
+	_ = x[DEC-18]
+	_ = x[Fujitsu-19]
+	_ = x[Infineon-20]
+	_ = x[Motorola-21]
+	_ = x[NVIDIA-22]
+	_ = x[AMCC-23]
+	_ = x[Qualcomm-24]
+	_ = x[Marvell-25]
+	_ = x[lastVendor-26]
 }
 
-const _Vendor_name = "VendorUnknownIntelAMDVIATransmetaNSCKVMMSVMVMwareXenHVMBhyveHygonSiSRDClastVendor"
+const _Vendor_name = "VendorUnknownIntelAMDVIATransmetaNSCKVMMSVMVMwareXenHVMBhyveHygonSiSRDCAmpereARMBroadcomCaviumDECFujitsuInfineonMotorolaNVIDIAAMCCQualcommMarvelllastVendor"
 
-var _Vendor_index = [...]uint8{0, 13, 18, 21, 24, 33, 36, 39, 43, 49, 55, 60, 65, 68, 71, 81}
+var _Vendor_index = [...]uint8{0, 13, 18, 21, 24, 33, 36, 39, 43, 49, 55, 60, 65, 68, 71, 77, 80, 88, 94, 97, 104, 112, 120, 126, 130, 138, 145, 155}
 
 func (i Vendor) String() string {
 	if i < 0 || i >= Vendor(len(_Vendor_index)-1) {

--- a/os_linux_arm64.go
+++ b/os_linux_arm64.go
@@ -5,9 +5,6 @@
 // license that can be found in the LICENSE file located
 // here https://github.com/golang/sys/blob/master/LICENSE
 
-//+build arm64
-//+build linux android
-
 package cpuid
 
 import (
@@ -137,7 +134,7 @@ func isSet(hwc uint, value uint) bool {
 }
 
 //go:noescape
-//go:linkname sched_getaffinity runtime·sched_getaffinity
+//go:linkname sched_getaffinity runtime.sched_getaffinity
 func sched_getaffinity(pid, len uintptr, buf *byte) int32
 
 func getproccount() int32 {

--- a/os_linux_arm64.go
+++ b/os_linux_arm64.go
@@ -14,7 +14,7 @@ import (
 	"encoding/binary"
 	"io/ioutil"
 	"runtime"
-	_ "unsafe" //required for go:linkname
+	"unsafe"
 )
 
 // HWCAP bits.
@@ -49,6 +49,10 @@ const (
 var hwcap uint
 
 func detectOS(c *CPUInfo) bool {
+	// For now assuming no hyperthreading is reasonable.
+	c.LogicalCores = int(getproccount())
+	c.PhysicalCores = c.LogicalCores
+	c.ThreadsPerCore = 1
 	if hwcap == 0 {
 		// We did not get values from the runtime.
 		// Try reading /proc/self/auxv
@@ -130,4 +134,31 @@ func detectOS(c *CPUInfo) bool {
 
 func isSet(hwc uint, value uint) bool {
 	return hwc&value != 0
+}
+
+//go:noescape
+//go:linkname sched_getaffinity runtime·sched_getaffinity
+func sched_getaffinity(pid, len uintptr, buf *byte) int32
+
+func getproccount() int32 {
+	// This buffer is huge (8 kB) but we are on the system stack
+	// and there should be plenty of space (64 kB).
+	// Also this is a leaf, so we're not holding up the memory for long.
+	const maxCPUs = 64 * 1024
+	var buf [maxCPUs / 8]byte
+	r := sched_getaffinity(0, unsafe.Sizeof(buf), &buf[0])
+	if r < 0 {
+		return 0
+	}
+	n := int32(0)
+	for _, v := range buf[:r] {
+		for v != 0 {
+			n += int32(v & 1)
+			v >>= 1
+		}
+	}
+	if n == 0 {
+		n = 1
+	}
+	return n
 }

--- a/os_other_arm64.go
+++ b/os_other_arm64.go
@@ -2,7 +2,6 @@
 
 // +build arm64
 // +build !linux
-// +build !android
 // +build !darwin
 
 package cpuid


### PR DESCRIPTION
Use `sched_getaffinity` to get a logical/physical core count.

This is of course not completely reliable, but is better than nothing.

Trust ARMCPUID and try to get some more information, like vendor, etc.
