### PR TITLE
Add //go:build lines

### DIFF
--- a/detect_arm64.go
+++ b/detect_arm64.go
@@ -1,6 +1,7 @@
 // Copyright (c) 2015 Klaus Post, released under MIT License. See LICENSE file.
 
-//+build arm64,!gccgo,!noasm,!appengine
+//go:build arm64 && !gccgo && !noasm && !appengine
+// +build arm64,!gccgo,!noasm,!appengine
 
 package cpuid
 

--- a/detect_ref.go
+++ b/detect_ref.go
@@ -1,6 +1,7 @@
 // Copyright (c) 2015 Klaus Post, released under MIT License. See LICENSE file.
 
-//+build !amd64,!386,!arm64 gccgo noasm appengine
+//go:build (!amd64 && !386 && !arm64) || gccgo || noasm || appengine
+// +build !amd64,!386,!arm64 gccgo noasm appengine
 
 package cpuid
 

--- a/detect_x86.go
+++ b/detect_x86.go
@@ -1,6 +1,7 @@
 // Copyright (c) 2015 Klaus Post, released under MIT License. See LICENSE file.
 
-//+build 386,!gccgo,!noasm,!appengine amd64,!gccgo,!noasm,!appengine
+//go:build (386 && !gccgo && !noasm && !appengine) || (amd64 && !gccgo && !noasm && !appengine)
+// +build 386,!gccgo,!noasm,!appengine amd64,!gccgo,!noasm,!appengine
 
 package cpuid
 

--- a/os_other_arm64.go
+++ b/os_other_arm64.go
@@ -1,8 +1,7 @@
 // Copyright (c) 2020 Klaus Post, released under MIT License. See LICENSE file.
 
-// +build arm64
-// +build !linux
-// +build !darwin
+//go:build arm64 && !linux && !darwin
+// +build arm64,!linux,!darwin
 
 package cpuid
 

--- a/os_safe_linux_arm64.go
+++ b/os_safe_linux_arm64.go
@@ -1,6 +1,7 @@
 // Copyright (c) 2021 Klaus Post, released under MIT License. See LICENSE file.
 
-//+build nounsafe
+//go:build nounsafe
+// +build nounsafe
 
 package cpuid
 

--- a/os_unsafe_linux_arm64.go
+++ b/os_unsafe_linux_arm64.go
@@ -1,6 +1,7 @@
 // Copyright (c) 2021 Klaus Post, released under MIT License. See LICENSE file.
 
-//+build !nounsafe
+//go:build !nounsafe
+// +build !nounsafe
 
 package cpuid
 


### PR DESCRIPTION
Starting with Go 1.17, `//go:build` lines are preferred over `// +build`
lines, see https://golang.org/doc/go1.17#build-lines and
https://golang.org/design/draft-gobuild for details.

This change was generated by running Go 1.17 `gofmt` which automatically
adds `//go:build` lines based on the existing `// +build` lines.