### PR TITLE
Try to fill darwin arm64 from sysctl

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/klauspost/cpuid/v2
 
 go 1.15
+
+require golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e h1:CsOuNlbOuf0mzxJIefr6Q4uAUetRUwZE4qt7VfzP+xo=
+golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/os_darwin_arm64.go
+++ b/os_darwin_arm64.go
@@ -115,7 +115,7 @@ func tryToFillCPUInfoFomSysctl(c *CPUInfo) {
 	setFeature(c, "hw.optional.armv8_1_atomics", ATOMICS)
 	setFeature(c, "hw.optional.floatingpoint", FP)
 	setFeature(c, "hw.optional.armv8_2_sha3", SHA3)
-	setFeature(c, "hw.optional.armv8_2_sha3", SHA512)
+	setFeature(c, "hw.optional.armv8_2_sha512", SHA512)
 	setFeature(c, "hw.optional.armv8_3_compnum", FCMA)
 	setFeature(c, "hw.optional.armv8_crc32", CRC32)
 }


### PR DESCRIPTION
Here is my try to fill CPUInfo from sysctl on darwin/arm64 when available.

on my laptop:
```
./cpuid -json
{
  "BrandName": "Apple M1 Pro",
  "VendorID": 0,
  "VendorString": "Apple",
  "PhysicalCores": 10,
  "ThreadsPerCore": 1,
  "LogicalCores": 10,
  "Family": 458787763,
  "Model": 16777228,
  "CacheLine": 128,
  "Hz": 0,
  "BoostFreq": 0,
  "Cache": {
    "L1I": 131072,
    "L1D": 131072,
    "L2": 4194304,
    "L3": -1
  },
  "SGX": {
    "Available": false,
    "LaunchControl": false,
    "SGX1Supported": false,
    "SGX2Supported": false,
    "MaxEnclaveSizeNot64": 0,
    "MaxEnclaveSize64": 0,
    "EPCSections": null
  },
  "Features": [
    "AESARM",
    "ASIMD",
    "ASIMDDP",
    "ASIMDHP",
    "ASIMDRDM",
    "ATOMICS",
    "CRC32",
    "DCPOP",
    "FCMA",
    "FP",
    "FPHP",
    "GPA",
    "JSCVT",
    "LRCPC",
    "PMULL",
    "SHA1",
    "SHA2",
    "SHA3",
    "SHA512"
  ],
  "X64Level": 0
}
```

data is from:
```
$ sysctl -a|grep cpu
kern.sched_rt_avoid_cpu0: 0
kern.cpu_checkin_interval: 4000
hw.ncpu: 10
hw.activecpu: 10
hw.perflevel0.physicalcpu: 8
hw.perflevel0.physicalcpu_max: 8
hw.perflevel0.logicalcpu: 8
hw.perflevel0.logicalcpu_max: 8
hw.perflevel0.cpusperl2: 4
hw.perflevel1.physicalcpu: 2
hw.perflevel1.physicalcpu_max: 2
hw.perflevel1.logicalcpu: 2
hw.perflevel1.logicalcpu_max: 2
hw.perflevel1.cpusperl2: 2
hw.physicalcpu: 10
hw.physicalcpu_max: 10
hw.logicalcpu: 10
hw.logicalcpu_max: 10
hw.cputype: 16777228
hw.cpusubtype: 2
hw.cpu64bit_capable: 1
hw.cpufamily: 458787763
hw.cpusubfamily: 4
machdep.cpu.cores_per_package: 10
machdep.cpu.core_count: 10
machdep.cpu.logical_per_package: 10
machdep.cpu.thread_count: 10
machdep.cpu.brand_string: Apple M1 Pro

$ sysctl -a|grep machdep
machdep.cpu.cores_per_package: 10
machdep.cpu.core_count: 10
machdep.cpu.logical_per_package: 10
machdep.cpu.thread_count: 10
machdep.cpu.brand_string: Apple M1 Pro
machdep.wake_abstime: 2406569708284
machdep.time_since_reset: 64757429384
machdep.wake_conttime: 4164013990606
machdep.deferred_ipi_timeout: 64000
machdep.lck_mtx_adaptive_spin_mode: 1
machdep.virtual_address_size: 47
machdep.report_phy_read_delay: 0
machdep.report_phy_write_delay: 0
machdep.trace_phy_read_delay: 0
machdep.trace_phy_write_delay: 0
machdep.report_phy_read_osbt: 0
machdep.report_phy_write_osbt: 0
machdep.phy_read_delay_panic: 0
machdep.phy_writedelay_panic: 0
machdep.user_idle_level: 0

$ sysctl -a|grep optional
hw.optional.arm.FEAT_FlagM: 1
hw.optional.arm.FEAT_FlagM2: 1
hw.optional.arm.FEAT_FHM: 1
hw.optional.arm.FEAT_DotProd: 1
hw.optional.arm.FEAT_SHA3: 1
hw.optional.arm.FEAT_RDM: 1
hw.optional.arm.FEAT_LSE: 1
hw.optional.arm.FEAT_SHA256: 1
hw.optional.arm.FEAT_SHA512: 1
hw.optional.arm.FEAT_SHA1: 1
hw.optional.arm.FEAT_AES: 1
hw.optional.arm.FEAT_PMULL: 1
hw.optional.arm.FEAT_SPECRES: 0
hw.optional.arm.FEAT_SB: 1
hw.optional.arm.FEAT_FRINTTS: 1
hw.optional.arm.FEAT_LRCPC: 1
hw.optional.arm.FEAT_LRCPC2: 1
hw.optional.arm.FEAT_FCMA: 1
hw.optional.arm.FEAT_JSCVT: 1
hw.optional.arm.FEAT_PAuth: 1
hw.optional.arm.FEAT_PAuth2: 0
hw.optional.arm.FEAT_FPAC: 0
hw.optional.arm.FEAT_DPB: 1
hw.optional.arm.FEAT_DPB2: 1
hw.optional.arm.FEAT_BF16: 0
hw.optional.arm.FEAT_I8MM: 0
hw.optional.arm.FEAT_ECV: 1
hw.optional.arm.FEAT_LSE2: 1
hw.optional.arm.FEAT_CSV2: 1
hw.optional.arm.FEAT_CSV3: 1
hw.optional.arm.FEAT_FP16: 1
hw.optional.arm.FEAT_SSBS: 1
hw.optional.arm.FEAT_BTI: 0
hw.optional.floatingpoint: 1
hw.optional.neon: 1
hw.optional.neon_hpfp: 1
hw.optional.neon_fp16: 1
hw.optional.armv8_1_atomics: 1
hw.optional.armv8_2_fhm: 1
hw.optional.armv8_2_sha512: 1
hw.optional.armv8_2_sha3: 1
hw.optional.armv8_3_compnum: 1
hw.optional.watchpoint: 4
hw.optional.breakpoint: 6
hw.optional.armv8_crc32: 1
hw.optional.armv8_gpi: 1
hw.optional.AdvSIMD: 1
hw.optional.AdvSIMD_HPFPCvt: 1
hw.optional.ucnormal_mem: 1
hw.optional.arm64: 1
```