### PR TITLE
Fixes MMXEXT

### DIFF
--- a/cpuid.go
+++ b/cpuid.go
@@ -1006,7 +1006,6 @@ func support() flagSet {
 	fs.setIf((d&(1<<8)) != 0, CMPXCHG8)
 	fs.setIf((d&(1<<11)) != 0, SYSEE)
 	fs.setIf((d&(1<<15)) != 0, CMOV)
-	fs.setIf((d&(1<<22)) != 0, MMXEXT)
 	fs.setIf((d&(1<<23)) != 0, MMX)
 	fs.setIf((d&(1<<24)) != 0, FXSR)
 	fs.setIf((d&(1<<25)) != 0, FXSROPT)


### PR DESCRIPTION
MMXEXT is defined in https://github.com/klauspost/cpuid/blob/45f166130b70caa073e0434192b876263c97f47d/cpuid.go#L1188
The removed line corresponds to `ACPI`  according to https://en.wikipedia.org/wiki/CPUID#EAX=1:_Processor_Info_and_Feature_Bits