### PR TITLE
Darwin L1 Data Cache fix

### DIFF
--- a/os_darwin_arm64.go
+++ b/os_darwin_arm64.go
@@ -83,7 +83,7 @@ func tryToFillCPUInfoFomSysctl(c *CPUInfo) {
 	c.Model = sysctlGetInt(0, "machdep.cpu.model")
 	c.CacheLine = sysctlGetInt64(0, "hw.cachelinesize")
 	c.Cache.L1I = sysctlGetInt64(-1, "hw.l1icachesize")
-	c.Cache.L1D = sysctlGetInt64(-1, "hw.l1icachesize")
+	c.Cache.L1D = sysctlGetInt64(-1, "hw.l1dcachesize")
 	c.Cache.L2 = sysctlGetInt64(-1, "hw.l2cachesize")
 	c.Cache.L3 = sysctlGetInt64(-1, "hw.l3cachesize")
 

--- a/os_darwin_test.go
+++ b/os_darwin_test.go
@@ -1,0 +1,44 @@
+package cpuid
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// Tests that the returned L1 instruction cache value matches the value returned from
+// a call to the OS `sysctl` utility. Skips the test if we can't run it.
+func TestDarwinL1ICache(t *testing.T) {
+	out, err := exec.Command("/usr/sbin/sysctl", "-n", "hw.l1icachesize").Output()
+	if err != nil {
+		t.Skipf("cannot run sysctl utility: %v", err)
+		return
+	}
+	v, err := strconv.ParseInt(strings.TrimSpace(string(out)), 10, 0)
+	if err != nil {
+		t.Skipf("sysctl output %q could not be parsed as int: %v", string(out), err)
+		return
+	}
+	if CPU.Cache.L1I != int(v) {
+		t.Fatalf("sysctl output %q did not match CPU.Cache.L1I %d", string(out), CPU.Cache.L1I)
+	}
+}
+
+// Tests that the returned L1 data cache value matches the value returned from a call
+// to the OS `sysctl` utility. Skips the test if we can't run it.
+func TestDarwinL1DCache(t *testing.T) {
+	out, err := exec.Command("/usr/sbin/sysctl", "-n", "hw.l1dcachesize").Output()
+	if err != nil {
+		t.Skipf("cannot run sysctl utility: %v", err)
+		return
+	}
+	v, err := strconv.ParseInt(strings.TrimSpace(string(out)), 10, 0)
+	if err != nil {
+		t.Skipf("sysctl output %q could not be parsed as int: %v", string(out), err)
+		return
+	}
+	if CPU.Cache.L1D != int(v) {
+		t.Fatalf("sysctl output %q did not match CPU.Cache.L1D %d", string(out), CPU.Cache.L1D)
+	}
+}


### PR DESCRIPTION
It appears there was a copy-paste error when implementing the L1 icache and dcache detection for Apple's silicon. This PR includes a test that detects the discrepancy and the fix.

Fixes #121