### PR TITLE
Add AMD Memory Encrypt detection

### DIFF
--- a/cmd/cpuid/main.go
+++ b/cmd/cpuid/main.go
@@ -82,4 +82,7 @@ func main() {
 	if cpuid.CPU.SGX.Available {
 		fmt.Printf("SGX: %+v\n", cpuid.CPU.SGX)
 	}
+	if cpuid.CPU.AMDMemEncryption.Available {
+		fmt.Printf("AMD Memory Encryption: %+v\n", cpuid.CPU.AMDMemEncryption)
+	}
 }

--- a/cpuid_test.go
+++ b/cpuid_test.go
@@ -136,6 +136,16 @@ func TestSGX(t *testing.T) {
 	}
 }
 
+// TestAMDMemEncryption tests AMDMemEncryption detection
+func TestAMDMemEncryption(t *testing.T) {
+	got := CPU.AMDMemEncryption.Available
+	expected := CPU.featureSet.inSet(SME) || CPU.featureSet.inSet(SEV)
+	if got != expected {
+		t.Fatalf("AMDMemEncryption: expected %v, got %v", expected, got)
+	}
+	t.Log("AMDMemEncryption Support:", got)
+}
+
 func TestHas(t *testing.T) {
 	Detect()
 	defer Detect()

--- a/detect_x86.go
+++ b/detect_x86.go
@@ -27,6 +27,7 @@ func addInfo(c *CPUInfo, safe bool) {
 	c.Family, c.Model, c.Stepping = familyModel()
 	c.featureSet = support()
 	c.SGX = hasSGX(c.featureSet.inSet(SGX), c.featureSet.inSet(SGXLC))
+	c.AMDMemEncryption = hasAMDMemEncryption(c.featureSet.inSet(SME) || c.featureSet.inSet(SEV))
 	c.ThreadsPerCore = threadsPerCore()
 	c.LogicalCores = logicalCores()
 	c.PhysicalCores = physicalCores()


### PR DESCRIPTION
This patch detects additional information of the AMD Memory Encryption feature.

[0]:
https://www.amd.com/content/dam/amd/en/documents/processor-tech-docs/programmer-references/24594.pdf table E.4.17