### PR TITLE
Add Hypervisor Vendor 

### DIFF
--- a/cpuid.go
+++ b/cpuid.go
@@ -55,6 +55,12 @@ const (
 	Qualcomm
 	Marvell
 
+	QEMU
+	QNX
+	ACRN
+	SRE
+	Apple
+
 	lastVendor
 )
 
@@ -881,6 +887,8 @@ var vendorMapping = map[string]Vendor{
 	"Geode by NSC": NSC,
 	"VIA VIA VIA ": VIA,
 	"KVMKVMKVM":    KVM,
+	"Linux KVM Hv": KVM,
+	"TCGTCGTCGTCG": QEMU,
 	"Microsoft Hv": MSVM,
 	"VMwareVMware": VMware,
 	"XenVMMXenVMM": XenHVM,
@@ -890,11 +898,26 @@ var vendorMapping = map[string]Vendor{
 	"SiS SiS SiS ": SiS,
 	"RiseRiseRise": SiS,
 	"Genuine  RDC": RDC,
+	"QNXQVMBSQG":   QNX,
+	"ACRNACRNACRN": ACRN,
+	"SRESRESRESRE": SRE,
+	"Apple VZ":     Apple,
 }
 
 func vendorID() (Vendor, string) {
 	_, b, c, d := cpuid(0)
 	v := string(valAsString(b, d, c))
+	vend, ok := vendorMapping[v]
+	if !ok {
+		return VendorUnknown, v
+	}
+	return vend, v
+}
+
+func hypervisorVendorID() (Vendor, string) {
+	// https://lwn.net/Articles/301888/
+	_, b, c, d := cpuid(0x40000000)
+	v := string(valAsString(b, c, d))
 	vend, ok := vendorMapping[v]
 	if !ok {
 		return VendorUnknown, v

--- a/cpuid.go
+++ b/cpuid.go
@@ -296,20 +296,22 @@ const (
 
 // CPUInfo contains information about the detected system CPU.
 type CPUInfo struct {
-	BrandName      string  // Brand name reported by the CPU
-	VendorID       Vendor  // Comparable CPU vendor ID
-	VendorString   string  // Raw vendor string.
-	featureSet     flagSet // Features of the CPU
-	PhysicalCores  int     // Number of physical processor cores in your CPU. Will be 0 if undetectable.
-	ThreadsPerCore int     // Number of threads per physical core. Will be 1 if undetectable.
-	LogicalCores   int     // Number of physical cores times threads that can run on each core through the use of hyperthreading. Will be 0 if undetectable.
-	Family         int     // CPU family number
-	Model          int     // CPU model number
-	Stepping       int     // CPU stepping info
-	CacheLine      int     // Cache line size in bytes. Will be 0 if undetectable.
-	Hz             int64   // Clock speed, if known, 0 otherwise. Will attempt to contain base clock speed.
-	BoostFreq      int64   // Max clock speed, if known, 0 otherwise
-	Cache          struct {
+	BrandName              string  // Brand name reported by the CPU
+	VendorID               Vendor  // Comparable CPU vendor ID
+	VendorString           string  // Raw vendor string.
+	HypervisorVendorID     Vendor  // Hypervisor vendor
+	HypervisorVendorString string  // Raw hypervisor vendor string
+	featureSet             flagSet // Features of the CPU
+	PhysicalCores          int     // Number of physical processor cores in your CPU. Will be 0 if undetectable.
+	ThreadsPerCore         int     // Number of threads per physical core. Will be 1 if undetectable.
+	LogicalCores           int     // Number of physical cores times threads that can run on each core through the use of hyperthreading. Will be 0 if undetectable.
+	Family                 int     // CPU family number
+	Model                  int     // CPU model number
+	Stepping               int     // CPU stepping info
+	CacheLine              int     // Cache line size in bytes. Will be 0 if undetectable.
+	Hz                     int64   // Clock speed, if known, 0 otherwise. Will attempt to contain base clock speed.
+	BoostFreq              int64   // Max clock speed, if known, 0 otherwise
+	Cache                  struct {
 		L1I int // L1 Instruction Cache (per core or shared). Will be -1 if undetected
 		L1D int // L1 Data Cache (per core or shared). Will be -1 if undetected
 		L2  int // L2 Cache (per core or shared). Will be -1 if undetected
@@ -318,8 +320,9 @@ type CPUInfo struct {
 	SGX              SGXSupport
 	AMDMemEncryption AMDMemEncryptionSupport
 	AVX10Level       uint8
-	maxFunc          uint32
-	maxExFunc        uint32
+
+	maxFunc   uint32
+	maxExFunc uint32
 }
 
 var cpuid func(op uint32) (eax, ebx, ecx, edx uint32)
@@ -877,7 +880,7 @@ var vendorMapping = map[string]Vendor{
 	"GenuineTMx86": Transmeta,
 	"Geode by NSC": NSC,
 	"VIA VIA VIA ": VIA,
-	"KVMKVMKVMKVM": KVM,
+	"KVMKVMKVM":    KVM,
 	"Microsoft Hv": MSVM,
 	"VMwareVMware": VMware,
 	"XenVMMXenVMM": XenHVM,

--- a/detect_x86.go
+++ b/detect_x86.go
@@ -32,6 +32,7 @@ func addInfo(c *CPUInfo, safe bool) {
 	c.LogicalCores = logicalCores()
 	c.PhysicalCores = physicalCores()
 	c.VendorID, c.VendorString = vendorID()
+	c.HypervisorVendorID, c.HypervisorVendorString = hypervisorVendorID()
 	c.AVX10Level = c.supportAVX10()
 	c.cacheSize()
 	c.frequencies()

--- a/featureid_string.go
+++ b/featureid_string.go
@@ -270,12 +270,17 @@ func _() {
 	_ = x[AMCC-23]
 	_ = x[Qualcomm-24]
 	_ = x[Marvell-25]
-	_ = x[lastVendor-26]
+	_ = x[QEMU-26]
+	_ = x[QNX-27]
+	_ = x[ACRN-28]
+	_ = x[SRE-29]
+	_ = x[Apple-30]
+	_ = x[lastVendor-31]
 }
 
-const _Vendor_name = "VendorUnknownIntelAMDVIATransmetaNSCKVMMSVMVMwareXenHVMBhyveHygonSiSRDCAmpereARMBroadcomCaviumDECFujitsuInfineonMotorolaNVIDIAAMCCQualcommMarvelllastVendor"
+const _Vendor_name = "VendorUnknownIntelAMDVIATransmetaNSCKVMMSVMVMwareXenHVMBhyveHygonSiSRDCAmpereARMBroadcomCaviumDECFujitsuInfineonMotorolaNVIDIAAMCCQualcommMarvellQEMUQNXACRNSREApplelastVendor"
 
-var _Vendor_index = [...]uint8{0, 13, 18, 21, 24, 33, 36, 39, 43, 49, 55, 60, 65, 68, 71, 77, 80, 88, 94, 97, 104, 112, 120, 126, 130, 138, 145, 155}
+var _Vendor_index = [...]uint8{0, 13, 18, 21, 24, 33, 36, 39, 43, 49, 55, 60, 65, 68, 71, 77, 80, 88, 94, 97, 104, 112, 120, 126, 130, 138, 145, 149, 152, 156, 159, 164, 174}
 
 func (i Vendor) String() string {
 	if i < 0 || i >= Vendor(len(_Vendor_index)-1) {

--- a/mockcpu_test.go
+++ b/mockcpu_test.go
@@ -98,7 +98,7 @@ func mockCPU(def []byte) func() {
 	}(idfuncs{cpuid: cpuid, cpuidex: cpuidex, xgetbv: xgetbv})
 
 	cpuid = func(op uint32) (eax, ebx, ecx, edx uint32) {
-		if op == 0x80000000 || op == 0 || op == 0x4000000c {
+		if op == 0x80000000 || op == 0 || op == 0x4000000c || op == 0x40000000 {
 			var ok bool
 			_, ok = fakeID[op]
 			if !ok {


### PR DESCRIPTION
Reads the hypervisor vendor as per https://lwn.net/Articles/301888/ and adds it to the `CPUInfo` struct. 

Also fixes the vendor mapping for `KVM`. 