### PR TITLE
Upgrade CI to 1.26, fix arm64 noasm

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,9 +10,9 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.22.x, 1.23.x, 1.24.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]  
-    runs-on: ubuntu-latest
+        go-version: [1.24.x, 1.25.x, 1.26.x]
+        os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
 
@@ -50,7 +50,7 @@ jobs:
       run: GOOS=linux GOARCH=386 go test -short ./...
 
     - name: goreleaser deprecation
-      run: curl -sfL https://git.io/goreleaser | VERSION=v2.3.2 sh -s -- check
+      run: curl -sfL https://git.io/goreleaser | VERSION=v2.16.0 sh -s -- check
       
     - name: goreleaser snapshot
-      run: curl -sL https://git.io/goreleaser | VERSION=v2.3.2 sh -s -- --snapshot --clean
+      run: curl -sL https://git.io/goreleaser | VERSION=v2.16.0 sh -s -- --snapshot --clean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,12 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.24.x
+          go-version: 1.26.x
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v7
         with:
-          version: 2.3.2
+          version: 2.16.0
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,7 +29,7 @@ archives:
     name_template: "cpuid-{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [ 'zip' ]
     files:
       - LICENSE
 checksum:

--- a/cpuid.go
+++ b/cpuid.go
@@ -17,6 +17,7 @@ import (
 	"math/bits"
 	"os"
 	"runtime"
+	"slices"
 	"strings"
 )
 
@@ -473,12 +474,7 @@ func (c *CPUInfo) Has(id FeatureID) bool {
 
 // AnyOf returns whether the CPU supports one or more of the requested features.
 func (c CPUInfo) AnyOf(ids ...FeatureID) bool {
-	for _, id := range ids {
-		if c.featureSet.inSet(id) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(ids, c.featureSet.inSet)
 }
 
 // Features contains several features combined for a fast check using
@@ -773,7 +769,7 @@ func flagSetWith(feat ...FeatureID) flagSet {
 // Will return UNKNOWN if not found.
 func ParseFeature(s string) FeatureID {
 	s = strings.ToUpper(s)
-	for i := firstID; i < lastID; i++ {
+	for i := range lastID {
 		if i.String() == s {
 			return i
 		}
@@ -787,7 +783,7 @@ func (s flagSet) Strings() []string {
 		return []string{""}
 	}
 	r := make([]string, 0)
-	for i := firstID; i < lastID; i++ {
+	for i := range lastID {
 		if s.inSet(i) {
 			r = append(r, i.String())
 		}
@@ -808,7 +804,7 @@ func maxFunctionID() uint32 {
 func brandName() string {
 	if maxExtendedFunction() >= 0x80000004 {
 		v := make([]uint32, 0, 48)
-		for i := uint32(0); i < 3; i++ {
+		for i := range uint32(3) {
 			a, b, c, d := cpuid(0x80000002 + i)
 			v = append(v, a, b, c, d)
 		}
@@ -1077,7 +1073,7 @@ func (c *CPUInfo) cacheSize() {
 		// Hack: When we encounter the same entry 100 times we break.
 		nSame := 0
 		var last uint32
-		for i := uint32(0); i < math.MaxUint32; i++ {
+		for i := range uint32(math.MaxUint32) {
 			eax, ebx, ecx, _ := cpuidex(0x8000001D, i)
 
 			level := (eax >> 5) & 7

--- a/cpuid_test.go
+++ b/cpuid_test.go
@@ -257,7 +257,7 @@ func ExampleCPUInfo_Ia32TscAux() {
 
 func TestCombineFeatures(t *testing.T) {
 	cpu := CPU
-	for i := FeatureID(0); i < lastID; i++ {
+	for i := range lastID {
 		if cpu.Has(i) != cpu.HasAll(CombineFeatures(i)) {
 			t.Errorf("id %d:%s mismatch", i, i.String())
 		}

--- a/detect_arm64.go
+++ b/detect_arm64.go
@@ -1,7 +1,6 @@
 // Copyright (c) 2015 Klaus Post, released under MIT License. See LICENSE file.
 
 //go:build arm64 && !gccgo && !noasm && !appengine
-// +build arm64,!gccgo,!noasm,!appengine
 
 package cpuid
 

--- a/detect_ref_arm64.go
+++ b/detect_ref_arm64.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2015 Klaus Post, released under MIT License. See LICENSE file.
 
-//go:build (!amd64 && !386 && !arm64) || ((amd64 || 386) && (gccgo || noasm || appengine))
+//go:build arm64 && (gccgo || noasm || appengine)
 
 package cpuid
 
@@ -9,8 +9,11 @@ func initCPU() {
 	cpuidex = func(x, y uint32) (a, b, c, d uint32) { return 0, 0, 0, 0 }
 	xgetbv = func(uint32) (a, b uint32) { return 0, 0 }
 	rdtscpAsm = func() (a, b, c, d uint32) { return 0, 0, 0, 0 }
-
 }
 
-func addInfo(info *CPUInfo, safe bool) {}
+func addInfo(c *CPUInfo, safe bool) {
+	c.CacheLine = 64
+	detectOS(c)
+}
+
 func getVectorLength() (vl, pl uint64) { return 0, 0 }

--- a/detect_x86.go
+++ b/detect_x86.go
@@ -1,7 +1,6 @@
 // Copyright (c) 2015 Klaus Post, released under MIT License. See LICENSE file.
 
 //go:build (386 && !gccgo && !noasm && !appengine) || (amd64 && !gccgo && !noasm && !appengine)
-// +build 386,!gccgo,!noasm,!appengine amd64,!gccgo,!noasm,!appengine
 
 package cpuid
 

--- a/os_other_arm64.go
+++ b/os_other_arm64.go
@@ -1,7 +1,6 @@
 // Copyright (c) 2020 Klaus Post, released under MIT License. See LICENSE file.
 
 //go:build arm64 && !linux && !darwin
-// +build arm64,!linux,!darwin
 
 package cpuid
 

--- a/os_safe_linux_arm64.go
+++ b/os_safe_linux_arm64.go
@@ -1,7 +1,6 @@
 // Copyright (c) 2021 Klaus Post, released under MIT License. See LICENSE file.
 
 //go:build nounsafe
-// +build nounsafe
 
 package cpuid
 

--- a/os_unsafe_linux_arm64.go
+++ b/os_unsafe_linux_arm64.go
@@ -1,7 +1,6 @@
 // Copyright (c) 2021 Klaus Post, released under MIT License. See LICENSE file.
 
 //go:build !nounsafe
-// +build !nounsafe
 
 package cpuid
 


### PR DESCRIPTION
When using 'noasm' it is still safe to use OS calls on arm64.

Applies `go fix`.