### PR TITLE
fix: update riscv vendor ids

### DIFF
--- a/cpuid.go
+++ b/cpuid.go
@@ -68,6 +68,8 @@ const (
 	THead
 	Andes
 	SpacemiT
+	Microchip
+	MIPS
 
 	lastVendor
 )

--- a/featureid_string.go
+++ b/featureid_string.go
@@ -356,12 +356,14 @@ func _() {
 	_ = x[THead-33]
 	_ = x[Andes-34]
 	_ = x[SpacemiT-35]
-	_ = x[lastVendor-36]
+	_ = x[Microchip-36]
+	_ = x[MIPS-37]
+	_ = x[lastVendor-38]
 }
 
-const _Vendor_name = "VendorUnknownIntelAMDVIATransmetaNSCKVMMSVMVMwareXenHVMBhyveHygonSiSRDCAmpereARMBroadcomCaviumDECFujitsuInfineonMotorolaNVIDIAAMCCQualcommMarvellQEMUQNXACRNSREAppleSiFiveStarFiveTHeadAndesSpacemiTlastVendor"
+const _Vendor_name = "VendorUnknownIntelAMDVIATransmetaNSCKVMMSVMVMwareXenHVMBhyveHygonSiSRDCAmpereARMBroadcomCaviumDECFujitsuInfineonMotorolaNVIDIAAMCCQualcommMarvellQEMUQNXACRNSREAppleSiFiveStarFiveTHeadAndesSpacemiTMicrochipMIPSlastVendor"
 
-var _Vendor_index = [...]uint8{0, 13, 18, 21, 24, 33, 36, 39, 43, 49, 55, 60, 65, 68, 71, 77, 80, 88, 94, 97, 104, 112, 120, 126, 130, 138, 145, 149, 152, 156, 159, 164, 170, 178, 183, 188, 196, 206}
+var _Vendor_index = [...]uint8{0, 13, 18, 21, 24, 33, 36, 39, 43, 49, 55, 60, 65, 68, 71, 77, 80, 88, 94, 97, 104, 112, 120, 126, 130, 138, 145, 149, 152, 156, 159, 164, 170, 178, 183, 188, 196, 205, 209, 219}
 
 func (i Vendor) String() string {
 	idx := int(i) - 0

--- a/riscv_isa.go
+++ b/riscv_isa.go
@@ -78,10 +78,11 @@ func parseISAString(c *CPUInfo, isa string) {
 }
 
 var riscvVendorMap = map[uint64]Vendor{
-	0x489: SiFive,
-	0x5b7: StarFive,
-	0x5b1: THead,
+	0x029: Microchip,
+	0x127: MIPS,
 	0x31e: Andes,
+	0x489: SiFive,
+	0x5b7: THead,
 	0x710: SpacemiT,
 }
 


### PR DESCRIPTION
Hello maintainers:

## Summary

This PR update the RISC-V vendor ID mapping to match the Linux kernel vendor ID list.

This adds the Linux-defined Microchip and MIPS vendor IDs, and corrects the `0x5b7` mapping to `THead`.

```bash
/* SPDX-License-Identifier: GPL-2.0-only */
/*
 * Copyright (C) 2021 SiFive
 */
#ifndef ASM_VENDOR_LIST_H
#define ASM_VENDOR_LIST_H

#define ANDES_VENDOR_ID		0x31e
#define MICROCHIP_VENDOR_ID	0x029
#define MIPS_VENDOR_ID		0x127
#define SIFIVE_VENDOR_ID	0x489
#define THEAD_VENDOR_ID		0x5b7

#endif
```

## References

Linux RISC-V vendor ID list: https://raw.githubusercontent.com/torvalds/linux/master/arch/riscv/include/asm/vendorid_list.h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added recognition for Microchip and MIPS CPU vendors.
  - Expanded vendor detection support for RISC-V processors.

- **Bug Fixes**
  - Corrected the T-Head vendor identifier mapping.
  - Updated RISC-V vendor mappings, including removal of the outdated StarFive entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->