### PR TITLE
Add amd64 CPU topology tree enumeration

### DIFF
--- a/cmd/cpuid/main.go
+++ b/cmd/cpuid/main.go
@@ -23,6 +23,7 @@ import (
 
 var js = flag.Bool("json", false, "Output as JSON")
 var level = flag.Int("check-level", 0, "Check microarchitecture level. Exit code will be 0 if supported")
+var topo = flag.Bool("topology", false, "Print the CPU topology tree (System > Package > Group > Core > Thread)")
 
 func main() {
 	flag.Parse()
@@ -36,6 +37,22 @@ func main() {
 			log.Fatalf("Microarchitecture level %d not supported. Max level is %d.", *level, cpuid.CPU.X64Level())
 		}
 		log.Printf("Microarchitecture level %d is supported. Max level is %d.", *level, cpuid.CPU.X64Level())
+		os.Exit(0)
+	}
+	if *topo {
+		sys, err := cpuid.ScanTopology()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Note:", err)
+		}
+		if *js {
+			b, err := json.MarshalIndent(sys, "", "  ")
+			if err != nil {
+				panic(err)
+			}
+			fmt.Println(string(b))
+		} else {
+			fmt.Print(sys.String())
+		}
 		os.Exit(0)
 	}
 	if *js {

--- a/cpuid.go
+++ b/cpuid.go
@@ -479,6 +479,7 @@ func init() {
 // exported CPU variable.
 func Detect() {
 	// Set defaults
+	topoSnapshot.Store(nil)
 	CPU.ThreadsPerCore = 1
 	CPU.Cache.L1I = -1
 	CPU.Cache.L1D = -1

--- a/internal/samplecpu/samplecpu.go
+++ b/internal/samplecpu/samplecpu.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Klaus Post, released under MIT License. See LICENSE file.
+
+// Package samplecpu provides a synthetic, deterministic CPU topology for the
+// cpuid module's own tests, examples and documentation. It is internal on
+// purpose: it is a fixture, not part of the public API.
+package samplecpu
+
+import "github.com/klauspost/cpuid/v2/topology"
+
+// Topology returns a synthetic topology: one package split into two groups (as
+// a hybrid CPU's tiles or an AMD CPU's CCDs would be) — a performance group of
+// two SMT cores and an efficiency group of four single-threaded cores, each
+// core with private L1/L2 and each group with a shared L3. It is not read from
+// any real CPU; use cpuid.ScanTopology or cpuid.CPU.Topology for that.
+func Topology() *topology.System {
+	core := func(id int, ct topology.CoreType, threads ...int) topology.Core {
+		c := topology.Core{ID: id, Type: ct, Caches: []topology.Cache{
+			{Level: 1, Type: topology.Data, Size: 32 << 10, LineSize: 64, SharedThreads: len(threads)},
+			{Level: 1, Type: topology.Instruction, Size: 32 << 10, LineSize: 64, SharedThreads: len(threads)},
+			{Level: 2, Type: topology.Unified, Size: 1 << 20, LineSize: 64, SharedThreads: len(threads)},
+		}}
+		for _, t := range threads {
+			c.Threads = append(c.Threads, topology.Thread{APICID: uint32(t), ID: t})
+		}
+		return c
+	}
+	group := func(id, shared int, cores ...topology.Core) topology.Group {
+		return topology.Group{ID: id, Cores: cores,
+			Caches: []topology.Cache{{Level: 3, Type: topology.Unified, Size: 16 << 20, LineSize: 64, SharedThreads: shared}}}
+	}
+	return &topology.System{
+		Vendor:  "GenuineIntel",
+		Scanned: true,
+		Online:  8,
+		Packages: []topology.Package{{Groups: []topology.Group{
+			group(0, 4, core(0, topology.Performance, 0, 1), core(1, topology.Performance, 2, 3)),
+			group(1, 4,
+				core(2, topology.Efficiency, 4), core(3, topology.Efficiency, 5),
+				core(4, topology.Efficiency, 6), core(5, topology.Efficiency, 7)),
+		}}},
+	}
+}

--- a/topology.go
+++ b/topology.go
@@ -1,0 +1,480 @@
+// Copyright (c) 2026 Klaus Post, released under MIT License. See LICENSE file.
+
+package cpuid
+
+import (
+	"cmp"
+	"math/bits"
+	"slices"
+	"sync/atomic"
+
+	"github.com/klauspost/cpuid/v2/topology"
+)
+
+// logicalCPU holds the topology-relevant CPUID data of a single logical
+// processor. It is produced by parseLogicalCPU on whichever CPU the calling
+// goroutine currently runs, so a full tree needs one per online CPU (see
+// ScanTopology); a single one drives the extrapolated snapshot.
+type logicalCPU struct {
+	apicID   uint32            // (x2)APIC id
+	vendor   Vendor            //
+	smtShift uint8             // apicID>>smtShift == core id
+	pkgShift uint8             // apicID>>pkgShift == package id
+	l3Shift  uint8             // apicID>>l3Shift  == L3 (group) id; 0 if no L3
+	nodeID   int               // AMD node id (leaf 0x8000001E ECX)
+	coreType topology.CoreType //
+	model    string            //
+	caches   []cpuCache        //
+}
+
+// cpuCache pairs a decoded cache with the addressable number of logical
+// processors that share it, which is what determines its sharing domain.
+type cpuCache struct {
+	c        topology.Cache
+	numShare int
+}
+
+// topoSnapshot caches the extrapolated single-CPU topology; Detect resets it.
+var topoSnapshot atomic.Pointer[topology.System]
+
+// Topology returns the CPU topology as a fixed hierarchy of
+// System → Package → Group → Core → Thread.
+//
+// It is extrapolated from the current core's CPUID and the detected core
+// counts, so counts and cache totals are accurate for homogeneous CPUs but
+// individual cores of a hybrid CPU cannot be classified. For an exact,
+// per-core tree (real efficiency/performance mapping and CCD membership) use
+// ScanTopology, which briefly pins the current goroutine to each CPU.
+func (c CPUInfo) Topology() *topology.System {
+	if t := topoSnapshot.Load(); t != nil {
+		return t
+	}
+	t := snapshotTopology()
+	topoSnapshot.Store(t)
+	return t
+}
+
+// parseLogicalCPU reads the topology leaves of the current logical processor.
+func parseLogicalCPU() logicalCPU {
+	var lc logicalCPU
+	lc.vendor, _ = vendorID()
+	mfi := maxFunctionID()
+	mef := maxExtendedFunction()
+
+	// Extended topology enumeration: leaf 0x1F (V2) is preferred over 0x0B.
+	// EAX[4:0] is the right-shift of the x2APIC id (EDX) that yields the id of
+	// the next coarser level; ECX[15:8] is the level type (1=SMT, 2=Core, …).
+	topoLeaf := uint32(0)
+	if mfi >= 0x1f {
+		if _, ebx, _, _ := cpuidex(0x1f, 0); ebx&0xffff != 0 {
+			topoLeaf = 0x1f
+		}
+	}
+	if topoLeaf == 0 && mfi >= 0xb {
+		if _, ebx, _, _ := cpuidex(0xb, 0); ebx&0xffff != 0 {
+			topoLeaf = 0xb
+		}
+	}
+	switch {
+	case topoLeaf != 0:
+		var maxShift uint8
+		for sub := range uint32(16) {
+			eax, ebx, ecx, edx := cpuidex(topoLeaf, sub)
+			if ebx&0xffff == 0 {
+				break
+			}
+			lc.apicID = edx
+			shift := uint8(eax & 0x1f)
+			if (ecx>>8)&0xff == 1 { // SMT level
+				lc.smtShift = shift
+			}
+			if shift > maxShift {
+				maxShift = shift
+			}
+		}
+		lc.pkgShift = maxShift
+	case mfi >= 1:
+		// Legacy 8-bit initial APIC id.
+		_, ebx, _, _ := cpuid(1)
+		lc.apicID = (ebx >> 24) & 0xff
+		lc.smtShift = ceilLog2(threadsPerCore())
+		lc.pkgShift = 8
+	}
+
+	if lc.vendor == AMD || lc.vendor == Hygon {
+		if mef >= 0x8000001e {
+			eax, ebx, ecx, _ := cpuid(0x8000001e)
+			if topoLeaf == 0 {
+				lc.apicID = eax // Extended APIC id, authoritative on AMD.
+			}
+			// EBX[15:8]+1 == threads per core, but only on Zen (fam>=0x17) and
+			// Hygon (fam 0x18); pre-Zen "modules" (fam 0x15/0x16) are not SMT.
+			if fam, _, _ := familyModel(); lc.smtShift == 0 && fam >= 0x17 {
+				lc.smtShift = ceilLog2(int((ebx>>8)&0xff) + 1)
+			}
+			lc.nodeID = int(ecx & 0xff)
+		}
+	}
+
+	lc.caches = parseCaches(lc.vendor, mfi, mef)
+	for _, cc := range lc.caches {
+		if cc.c.Level == 3 {
+			lc.l3Shift = ceilLog2(cc.numShare)
+		}
+	}
+	lc.coreType, lc.model = parseCoreType(lc.vendor, mfi)
+	return lc
+}
+
+// parseCaches decodes the deterministic cache leaves (Intel 0x04 / AMD
+// 0x8000001D). AMD only populates 0x8000001D when TopologyExtensions is set.
+func parseCaches(vendor Vendor, mfi, mef uint32) []cpuCache {
+	var out []cpuCache
+	switch vendor {
+	case Intel:
+		if mfi < 4 {
+			return nil
+		}
+		for i := range uint32(16) {
+			eax, ebx, ecx, edx := cpuidex(4, i)
+			if eax&0xf == 0 {
+				break
+			}
+			out = append(out, decodeCache(eax, ebx, ecx, edx))
+		}
+	case AMD, Hygon:
+		topext := false
+		if mef >= 0x80000001 {
+			_, _, ecx, _ := cpuid(0x80000001)
+			topext = ecx&(1<<22) != 0
+		}
+		if mef >= 0x8000001d && topext {
+			for i := range uint32(16) {
+				eax, ebx, ecx, edx := cpuidex(0x8000001d, i)
+				if eax&0xf == 0 {
+					break
+				}
+				out = append(out, decodeCache(eax, ebx, ecx, edx))
+			}
+		}
+	}
+	return out
+}
+
+// decodeCache reads one subleaf of leaf 0x04 / 0x8000001D, which share layout.
+func decodeCache(eax, ebx, ecx, edx uint32) cpuCache {
+	line := int(ebx&0xfff) + 1
+	parts := int((ebx>>12)&0x3ff) + 1
+	ways := int((ebx>>22)&0x3ff) + 1
+	sets := int(ecx) + 1
+	return cpuCache{
+		c: topology.Cache{
+			Level:     int((eax >> 5) & 7),
+			Type:      topology.CacheType(eax & 0xf), // 1=Data, 2=Instruction, 3=Unified
+			Size:      line * parts * ways * sets,
+			LineSize:  line,
+			Ways:      ways,
+			Sets:      sets,
+			Inclusive: edx&2 != 0,
+		},
+		numShare: int((eax>>14)&0xfff) + 1,
+	}
+}
+
+// parseCoreType classifies the current core from Intel's hybrid leaf 0x1A.
+// The leaf reads 0 on non-hybrid Intel parts (so they fall through to
+// performance), but all-efficiency parts populate it without the hybrid flag,
+// so it is read whenever present rather than gated on that flag.
+func parseCoreType(vendor Vendor, mfi uint32) (topology.CoreType, string) {
+	if vendor == Intel && mfi >= 0x1a {
+		switch eax, _, _, _ := cpuid(0x1a); eax >> 24 {
+		case 0x40:
+			return topology.Performance, ""
+		case 0x20:
+			return topology.Efficiency, ""
+		}
+	}
+	if vendor == Intel || vendor == AMD || vendor == Hygon {
+		return topology.Performance, ""
+	}
+	return topology.Unknown, ""
+}
+
+// assembleTopology builds the exact tree from one record per logical CPU.
+// Package/group/core membership is derived by masking the x2APIC id, and each
+// cache instance is attached to the deepest node that contains every logical
+// processor sharing it, so aggregate sizes never double-count.
+func assembleTopology(cpus []logicalCPU) *topology.System {
+	sys := &topology.System{Scanned: true, Online: len(cpus)}
+	if len(cpus) == 0 {
+		return sys
+	}
+	sys.Vendor = cpus[0].vendor.String()
+
+	groupShiftOf := func(lc logicalCPU) uint8 {
+		s := lc.l3Shift
+		if s == 0 {
+			s = lc.pkgShift // no L3: one group spans the package
+		}
+		if s < lc.smtShift {
+			s = lc.smtShift
+		}
+		if s == 0 {
+			s = 32
+		}
+		return s
+	}
+
+	type coreData struct {
+		typ     topology.CoreType
+		model   string
+		threads []topology.Thread
+	}
+	cores := map[uint32]*coreData{}
+	groupOf := map[uint32]uint32{} // coreKey -> groupKey
+	pkgOf := map[uint32]uint32{}   // groupKey -> pkgKey
+	nodeOf := map[uint32]int{}     // groupKey -> NUMA node
+	pkgSet := map[uint32]bool{}
+	var pkgKeys, groupKeys, coreKeys []uint32
+
+	for i, lc := range cpus {
+		pk := lc.apicID >> lc.pkgShift
+		gk := lc.apicID >> groupShiftOf(lc)
+		ck := lc.apicID >> lc.smtShift
+		cd := cores[ck]
+		if cd == nil {
+			cd = &coreData{typ: lc.coreType, model: lc.model}
+			cores[ck] = cd
+			coreKeys = append(coreKeys, ck)
+			groupOf[ck] = gk
+		}
+		if _, ok := pkgOf[gk]; !ok {
+			pkgOf[gk] = pk
+			groupKeys = append(groupKeys, gk)
+		}
+		nodeOf[gk] = lc.nodeID
+		if !pkgSet[pk] {
+			pkgSet[pk] = true
+			pkgKeys = append(pkgKeys, pk)
+		}
+		cd.threads = append(cd.threads, topology.Thread{APICID: lc.apicID, ID: i})
+	}
+
+	coreCaches, groupCaches, pkgCaches := attachCaches(cpus, groupShiftOf)
+
+	slices.Sort(pkgKeys)
+	slices.Sort(groupKeys)
+	slices.Sort(coreKeys)
+
+	coreID, groupID := 0, 0
+	for pi, pk := range pkgKeys {
+		p := topology.Package{ID: pi, Caches: sortCaches(pkgCaches[pk])}
+		for _, gk := range groupKeys {
+			if pkgOf[gk] != pk {
+				continue
+			}
+			g := topology.Group{ID: groupID, NUMANode: nodeOf[gk], Caches: sortCaches(groupCaches[gk])}
+			groupID++
+			for _, ck := range coreKeys {
+				if groupOf[ck] != gk {
+					continue
+				}
+				cd := cores[ck]
+				slices.SortFunc(cd.threads, func(a, b topology.Thread) int { return cmp.Compare(a.APICID, b.APICID) })
+				g.Cores = append(g.Cores, topology.Core{
+					ID:      coreID,
+					Type:    cd.typ,
+					Model:   cd.model,
+					Threads: cd.threads,
+					Caches:  sortCaches(coreCaches[ck]),
+				})
+				coreID++
+			}
+			p.Groups = append(p.Groups, g)
+		}
+		sys.Packages = append(sys.Packages, p)
+	}
+	return sys
+}
+
+// attachCaches groups every reported cache into instances by sharing domain
+// and returns them keyed by the core/group/package they belong to.
+func attachCaches(cpus []logicalCPU, groupShiftOf func(logicalCPU) uint8) (core, group, pkg map[uint32][]topology.Cache) {
+	type cacheKey struct {
+		level int
+		typ   topology.CacheType
+		dom   uint32
+	}
+	type cacheAgg struct {
+		c      topology.Cache
+		cores  map[uint32]bool
+		groups map[uint32]bool
+		pkgs   map[uint32]bool
+		shared int
+	}
+	insts := map[cacheKey]*cacheAgg{}
+	for _, lc := range cpus {
+		pk := lc.apicID >> lc.pkgShift
+		gk := lc.apicID >> groupShiftOf(lc)
+		ck := lc.apicID >> lc.smtShift
+		for _, cc := range lc.caches {
+			key := cacheKey{cc.c.Level, cc.c.Type, lc.apicID >> ceilLog2(cc.numShare)}
+			a := insts[key]
+			if a == nil {
+				a = &cacheAgg{c: cc.c, cores: map[uint32]bool{}, groups: map[uint32]bool{}, pkgs: map[uint32]bool{}}
+				insts[key] = a
+			}
+			a.cores[ck], a.groups[gk], a.pkgs[pk] = true, true, true
+			a.shared++
+		}
+	}
+	core, group, pkg = map[uint32][]topology.Cache{}, map[uint32][]topology.Cache{}, map[uint32][]topology.Cache{}
+	for _, a := range insts {
+		c := a.c
+		c.SharedThreads = a.shared
+		switch {
+		case len(a.cores) == 1:
+			k := onlyKey(a.cores)
+			core[k] = append(core[k], c)
+		case len(a.groups) == 1:
+			k := onlyKey(a.groups)
+			group[k] = append(group[k], c)
+		default:
+			k := onlyKey(a.pkgs)
+			pkg[k] = append(pkg[k], c)
+		}
+	}
+	return core, group, pkg
+}
+
+// snapshotTopology extrapolates a homogeneous tree from the current core and
+// the detected core counts, without pinning to other CPUs.
+func snapshotTopology() *topology.System {
+	if cpuid == nil {
+		return countsTopology() // Non-x86: no CPUID, build from detected counts.
+	}
+	lc := parseLogicalCPU()
+	tpc := max(threadsPerCore(), 1)
+	physical := max(physicalCores(), 1)
+	logical := max(logicalCores(), physical*tpc)
+
+	var l1d, l1i, l2, l3 *topology.Cache
+	l3Share := 0
+	for i := range lc.caches {
+		cc := &lc.caches[i]
+		switch {
+		case cc.c.Level == 1 && cc.c.Type == topology.Instruction:
+			l1i = &cc.c
+		case cc.c.Level == 1:
+			l1d = &cc.c
+		case cc.c.Level == 2:
+			l2 = &cc.c
+		case cc.c.Level == 3:
+			l3 = &cc.c
+			l3Share = cc.numShare
+		}
+	}
+
+	coresPerGroup := physical
+	if l3Share > 0 && l3Share/tpc > 0 {
+		coresPerGroup = l3Share / tpc
+	}
+	coresPerGroup = min(coresPerGroup, physical)
+	groups := 1
+	if coresPerGroup > 0 {
+		groups = (physical + coresPerGroup - 1) / coresPerGroup
+	}
+
+	sys := &topology.System{Vendor: lc.vendor.String(), Online: logical}
+	pkg := topology.Package{}
+	coreID, apic, remaining := 0, uint32(0), physical
+	for g := range groups {
+		grp := topology.Group{ID: g, NUMANode: lc.nodeID}
+		n := min(coresPerGroup, remaining)
+		for range n {
+			core := topology.Core{ID: coreID, Type: lc.coreType, Model: lc.model}
+			for range tpc {
+				core.Threads = append(core.Threads, topology.Thread{APICID: apic, ID: int(apic)})
+				apic++
+			}
+			addCache(&core.Caches, l1d, tpc)
+			addCache(&core.Caches, l1i, tpc)
+			addCache(&core.Caches, l2, tpc)
+			grp.Cores = append(grp.Cores, core)
+			coreID++
+		}
+		addCache(&grp.Caches, l3, n*tpc)
+		remaining -= n
+		pkg.Groups = append(pkg.Groups, grp)
+	}
+	sys.Packages = []topology.Package{pkg}
+	return sys
+}
+
+func addCache(dst *[]topology.Cache, c *topology.Cache, shared int) {
+	if c == nil || c.Size == 0 {
+		return
+	}
+	cc := *c
+	cc.SharedThreads = shared
+	*dst = append(*dst, cc)
+}
+
+// countsTopology builds a minimal tree from the already-detected counts and
+// cache sizes, used where CPUID is not available (non-x86, or noasm builds).
+func countsTopology() *topology.System {
+	tpc := max(CPU.ThreadsPerCore, 1)
+	physical := CPU.PhysicalCores
+	if physical < 1 {
+		physical = max(1, CPU.LogicalCores/tpc)
+	}
+	sys := &topology.System{Vendor: CPU.VendorString, Online: CPU.LogicalCores}
+	var grp topology.Group
+	id := 0
+	for c := range physical {
+		core := topology.Core{ID: c, Type: topology.Performance}
+		for range tpc {
+			core.Threads = append(core.Threads, topology.Thread{ID: id})
+			id++
+		}
+		addCacheVal(&core.Caches, 1, topology.Data, CPU.Cache.L1D, tpc)
+		addCacheVal(&core.Caches, 1, topology.Instruction, CPU.Cache.L1I, tpc)
+		addCacheVal(&core.Caches, 2, topology.Unified, CPU.Cache.L2, tpc)
+		grp.Cores = append(grp.Cores, core)
+	}
+	addCacheVal(&grp.Caches, 3, topology.Unified, CPU.Cache.L3, physical*tpc)
+	sys.Packages = []topology.Package{{Groups: []topology.Group{grp}}}
+	return sys
+}
+
+func addCacheVal(dst *[]topology.Cache, level int, t topology.CacheType, size, shared int) {
+	if size <= 0 {
+		return
+	}
+	*dst = append(*dst, topology.Cache{Level: level, Type: t, Size: size, SharedThreads: shared})
+}
+
+func sortCaches(cs []topology.Cache) []topology.Cache {
+	slices.SortFunc(cs, func(a, b topology.Cache) int {
+		if a.Level != b.Level {
+			return cmp.Compare(a.Level, b.Level)
+		}
+		return cmp.Compare(a.Type, b.Type)
+	})
+	return cs
+}
+
+func onlyKey(m map[uint32]bool) uint32 {
+	for k := range m {
+		return k
+	}
+	return 0
+}
+
+// ceilLog2 returns the smallest s such that 1<<s >= n.
+func ceilLog2(n int) uint8 {
+	if n <= 1 {
+		return 0
+	}
+	return uint8(bits.Len(uint(n - 1)))
+}

--- a/topology/example_test.go
+++ b/topology/example_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Klaus Post, released under MIT License. See LICENSE file.
+
+package topology_test
+
+import (
+	"fmt"
+
+	"github.com/klauspost/cpuid/v2"
+	"github.com/klauspost/cpuid/v2/internal/samplecpu"
+	"github.com/klauspost/cpuid/v2/topology"
+)
+
+// Example shows how to obtain and inspect the topology of the running machine.
+func Example() {
+	// ScanTopology pins the calling goroutine to every online CPU to build an
+	// exact tree. For a cheaper approximation that does no pinning, use
+	// cpuid.CPU.Topology() instead. On unsupported platforms ScanTopology
+	// returns a best-effort snapshot together with a non-nil error.
+	sys, _ := cpuid.ScanTopology()
+
+	fmt.Printf("%s: %d package(s), %d cores, %d threads\n",
+		sys.Vendor, sys.NumPackages(), sys.NumCores(), sys.NumThreads())
+	fmt.Printf("performance cores: %d, efficiency cores: %d\n",
+		sys.CoresByType()[topology.Performance], sys.CoresByType()[topology.Efficiency])
+	fmt.Printf("total L3: %d bytes\n", sys.TotalCache(3, topology.Unified))
+
+	// Output varies by machine, so it is not checked here. The method examples
+	// below use a fixed synthetic topology for reproducible output.
+}
+
+// ExampleSystem_TotalCache totals a cache level below any node: the whole
+// system, or a single group (CCD/tile). Each physical instance is counted once.
+func ExampleSystem_TotalCache() {
+	sys := samplecpu.Topology()
+	fmt.Printf("L3 total:       %d MB\n", sys.TotalCache(3, topology.Unified)>>20)
+	fmt.Printf("L3 in group #0: %d MB\n", sys.Packages[0].Groups[0].TotalCache(3, topology.Unified)>>20)
+	fmt.Printf("L2 total:       %d MB\n", sys.TotalCache(2, topology.Unified)>>20)
+	// Output:
+	// L3 total:       32 MB
+	// L3 in group #0: 16 MB
+	// L2 total:       6 MB
+}
+
+// ExampleSystem_CoresByType counts cores per type, e.g. to tell how many
+// performance and efficiency cores a hybrid CPU has.
+func ExampleSystem_CoresByType() {
+	sys := samplecpu.Topology()
+	byType := sys.CoresByType()
+	fmt.Printf("performance: %d\n", byType[topology.Performance])
+	fmt.Printf("efficiency:  %d\n", byType[topology.Efficiency])
+	fmt.Printf("threads:     %d\n", sys.NumThreads())
+	// Output:
+	// performance: 2
+	// efficiency:  4
+	// threads:     8
+}
+
+// ExampleSystem_String prints the topology as an indented tree.
+func ExampleSystem_String() {
+	fmt.Print(samplecpu.Topology())
+	// Output:
+	// System: GenuineIntel (scanned) — 1 package(s), 6 core(s), 8 thread(s)
+	//   Package #0
+	//     Group #0  [L3 16MB]
+	//       Core #0 (Performance) threads: 0, 1  [L1d 32KB L1i 32KB L2 1MB]
+	//       Core #1 (Performance) threads: 2, 3  [L1d 32KB L1i 32KB L2 1MB]
+	//     Group #1  [L3 16MB]
+	//       Core #2 (Efficiency) threads: 4  [L1d 32KB L1i 32KB L2 1MB]
+	//       Core #3 (Efficiency) threads: 5  [L1d 32KB L1i 32KB L2 1MB]
+	//       Core #4 (Efficiency) threads: 6  [L1d 32KB L1i 32KB L2 1MB]
+	//       Core #5 (Efficiency) threads: 7  [L1d 32KB L1i 32KB L2 1MB]
+	//   Cores by type: Performance=2 Efficiency=4
+	//   Total cache: L1D 192KB, L1I 192KB, L2 6MB, L3 32MB
+}

--- a/topology/topology.go
+++ b/topology/topology.go
@@ -1,0 +1,389 @@
+// Copyright (c) 2026 Klaus Post, released under MIT License. See LICENSE file.
+
+// Package topology describes the layout of a system's CPUs as a fixed
+// hierarchy: System → Package → Group → Core → Thread.
+//
+// A Package is a socket (a physical "CPU"). A Group is a set of cores that
+// share a last-level cache — an AMD CCX/CCD or an Intel LLC tile; there is
+// always at least one, so a monolithic chip has a single Group holding the
+// whole L3. A Core carries its type (performance/efficiency/…), its shared
+// per-core caches and its logical Threads.
+//
+// Caches are attached to the level that owns them: L1/L2 on a Core, the
+// shared L3 on a Group, a package-wide last-level cache on a Package. Because
+// every instance is stored exactly once, the TotalCache aggregate never
+// double-counts: System.TotalCache(3, Unified) is the combined L3 across all
+// groups (e.g. all CCDs).
+//
+// The package holds types and queries only; it is filled in by the cpuid
+// package and has no dependencies of its own.
+package topology
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CacheType identifies what a cache stores. The values match the type field
+// of CPUID leaves 0x04 / 0x8000001D.
+type CacheType uint8
+
+const (
+	Data        CacheType = iota + 1 // Data cache
+	Instruction                      // Instruction cache
+	Unified                          // Unified cache (holds both)
+)
+
+func (t CacheType) String() string {
+	switch t {
+	case Data:
+		return "Data"
+	case Instruction:
+		return "Instruction"
+	case Unified:
+		return "Unified"
+	}
+	return "Unknown"
+}
+
+// MarshalText renders the cache type as its name, so it serializes as a string
+// in JSON and other text encodings rather than a number.
+func (t CacheType) MarshalText() ([]byte, error) { return []byte(t.String()), nil }
+
+// CoreType is the microarchitectural class of a core. On heterogeneous
+// ("hybrid") CPUs this distinguishes performance from efficiency cores.
+type CoreType uint8
+
+const (
+	Unknown      CoreType = iota // Type could not be determined
+	Performance                  // Intel P-core (leaf 0x1A == 0x40), AMD classic Zen core
+	Efficiency                   // Intel E-core (leaf 0x1A == 0x20)
+	LPEfficiency                 // Intel low-power E-core on the SoC tile
+	Dense                        // AMD dense core (Zen 4c / 5c)
+)
+
+func (t CoreType) String() string {
+	switch t {
+	case Performance:
+		return "Performance"
+	case Efficiency:
+		return "Efficiency"
+	case LPEfficiency:
+		return "LP-Efficiency"
+	case Dense:
+		return "Dense"
+	}
+	return "Unknown"
+}
+
+// MarshalText renders the core type as its name for JSON and other text
+// encodings.
+func (t CoreType) MarshalText() ([]byte, error) { return []byte(t.String()), nil }
+
+// Cache describes a single cache instance.
+type Cache struct {
+	Level         int       // 1, 2, 3, …
+	Type          CacheType // Data, Instruction or Unified
+	Size          int       // Size in bytes of this instance
+	LineSize      int       // Line size in bytes
+	Ways          int       // Associativity
+	Sets          int       // Number of sets
+	SharedThreads int       // Logical processors that share this instance
+	Inclusive     bool      // Inclusive of lower cache levels
+}
+
+// Thread is a single logical processor.
+type Thread struct {
+	APICID uint32 // (x2)APIC id
+	ID     int    // OS logical CPU number if known from a scan, else the enumeration index
+}
+
+// Core is a single physical core and the threads it runs.
+type Core struct {
+	ID      int
+	Type    CoreType
+	Model   string   // Microarchitecture label if known, e.g. "Golden Cove"
+	Threads []Thread // More than one indicates SMT / hyper-threading
+	Caches  []Cache  // Caches private to this core, typically L1 and L2
+}
+
+// NumThreads returns the number of logical processors on the core.
+func (c *Core) NumThreads() int { return len(c.Threads) }
+
+// TotalCache returns the size in bytes of the core-private caches of the
+// given level and type.
+func (c *Core) TotalCache(level int, t CacheType) int { return sumCaches(c.Caches, level, t) }
+
+// Group is a set of cores sharing a last-level cache — an AMD CCX/CCD or an
+// Intel LLC tile. There is always at least one per package.
+type Group struct {
+	ID       int
+	NUMANode int     // AMD node id (leaf 0x8000001E ECX); 0 when unknown or single-node
+	Cores    []Core  // Cores in the group
+	Caches   []Cache // Caches shared by the whole group, typically L3
+}
+
+// NumCores returns the number of cores in the group.
+func (g *Group) NumCores() int { return len(g.Cores) }
+
+// NumThreads returns the number of logical processors below the group.
+func (g *Group) NumThreads() int { return countThreads(g.Cores) }
+
+// CoresByType returns a count of cores per CoreType within the group.
+func (g *Group) CoresByType() map[CoreType]int { return coresByType(g.Cores) }
+
+// TotalCache sums the caches of the given level and type at and below the
+// group, counting each instance once.
+func (g *Group) TotalCache(level int, t CacheType) int {
+	return sumCaches(g.Caches, level, t) + coresCache(g.Cores, level, t)
+}
+
+// Package is a socket / physical CPU.
+type Package struct {
+	ID     int
+	Groups []Group
+	Caches []Cache // Package-wide caches, if any
+}
+
+// NumCores returns the number of cores in the package.
+func (p *Package) NumCores() int {
+	n := 0
+	for i := range p.Groups {
+		n += len(p.Groups[i].Cores)
+	}
+	return n
+}
+
+// NumThreads returns the number of logical processors in the package.
+func (p *Package) NumThreads() int {
+	n := 0
+	for i := range p.Groups {
+		n += p.Groups[i].NumThreads()
+	}
+	return n
+}
+
+// CoresByType returns a count of cores per CoreType within the package.
+func (p *Package) CoresByType() map[CoreType]int {
+	m := map[CoreType]int{}
+	for i := range p.Groups {
+		mergeCounts(m, p.Groups[i].Cores)
+	}
+	return m
+}
+
+// Cores returns every core in the package.
+func (p *Package) Cores() []Core {
+	var out []Core
+	for i := range p.Groups {
+		out = append(out, p.Groups[i].Cores...)
+	}
+	return out
+}
+
+// TotalCache sums the caches of the given level and type at and below the
+// package, counting each instance once.
+func (p *Package) TotalCache(level int, t CacheType) int {
+	n := sumCaches(p.Caches, level, t)
+	for i := range p.Groups {
+		n += p.Groups[i].TotalCache(level, t)
+	}
+	return n
+}
+
+// System is the root of the topology: the whole machine.
+type System struct {
+	Vendor   string    // CPU vendor string
+	Scanned  bool      // true if built from a per-core scan, false if extrapolated from one core
+	Online   int       // Logical processors observed
+	Packages []Package // Physical packages / sockets
+}
+
+// NumPackages returns the number of packages (sockets).
+func (s *System) NumPackages() int { return len(s.Packages) }
+
+// NumCores returns the total number of physical cores in the system.
+func (s *System) NumCores() int {
+	n := 0
+	for i := range s.Packages {
+		n += s.Packages[i].NumCores()
+	}
+	return n
+}
+
+// NumThreads returns the total number of logical processors in the system.
+func (s *System) NumThreads() int {
+	n := 0
+	for i := range s.Packages {
+		n += s.Packages[i].NumThreads()
+	}
+	return n
+}
+
+// CoresByType returns a count of cores per CoreType across the system.
+func (s *System) CoresByType() map[CoreType]int {
+	m := map[CoreType]int{}
+	for i := range s.Packages {
+		for j := range s.Packages[i].Groups {
+			mergeCounts(m, s.Packages[i].Groups[j].Cores)
+		}
+	}
+	return m
+}
+
+// Cores returns every core in the system.
+func (s *System) Cores() []Core {
+	var out []Core
+	for i := range s.Packages {
+		out = append(out, s.Packages[i].Cores()...)
+	}
+	return out
+}
+
+// TotalCache sums the caches of the given level and type across the whole
+// system, counting each instance once. For example TotalCache(3, Unified)
+// returns the combined L3 across all groups.
+func (s *System) TotalCache(level int, t CacheType) int {
+	n := 0
+	for i := range s.Packages {
+		n += s.Packages[i].TotalCache(level, t)
+	}
+	return n
+}
+
+func sumCaches(cs []Cache, level int, t CacheType) int {
+	n := 0
+	for _, c := range cs {
+		if c.Level == level && c.Type == t {
+			n += c.Size
+		}
+	}
+	return n
+}
+
+func coresCache(cs []Core, level int, t CacheType) int {
+	n := 0
+	for i := range cs {
+		n += sumCaches(cs[i].Caches, level, t)
+	}
+	return n
+}
+
+func countThreads(cs []Core) int {
+	n := 0
+	for i := range cs {
+		n += len(cs[i].Threads)
+	}
+	return n
+}
+
+func coresByType(cs []Core) map[CoreType]int {
+	m := map[CoreType]int{}
+	mergeCounts(m, cs)
+	return m
+}
+
+func mergeCounts(m map[CoreType]int, cs []Core) {
+	for i := range cs {
+		m[cs[i].Type]++
+	}
+}
+
+// String renders the topology as an indented tree, followed by a summary.
+func (s *System) String() string {
+	var b strings.Builder
+	kind := "extrapolated from one core"
+	if s.Scanned {
+		kind = "scanned"
+	}
+	fmt.Fprintf(&b, "System: %s (%s) — %d package(s), %d core(s), %d thread(s)\n",
+		s.Vendor, kind, s.NumPackages(), s.NumCores(), s.NumThreads())
+	for pi := range s.Packages {
+		p := &s.Packages[pi]
+		fmt.Fprintf(&b, "  Package #%d%s\n", p.ID, cacheSuffix(p.Caches))
+		for gi := range p.Groups {
+			g := &p.Groups[gi]
+			numa := ""
+			if g.NUMANode != 0 {
+				numa = fmt.Sprintf(" NUMA#%d", g.NUMANode)
+			}
+			fmt.Fprintf(&b, "    Group #%d%s%s\n", g.ID, numa, cacheSuffix(g.Caches))
+			for ci := range g.Cores {
+				c := &g.Cores[ci]
+				model := ""
+				if c.Model != "" {
+					model = " " + c.Model
+				}
+				fmt.Fprintf(&b, "      Core #%d (%s%s) threads:%s%s\n",
+					c.ID, c.Type, model, threadList(c.Threads), cacheSuffix(c.Caches))
+			}
+		}
+	}
+	if types := s.CoresByType(); len(types) > 1 || !hasOnly(types, Performance) {
+		b.WriteString("  Cores by type:")
+		for _, t := range []CoreType{Performance, Efficiency, LPEfficiency, Dense, Unknown} {
+			if n := types[t]; n > 0 {
+				fmt.Fprintf(&b, " %s=%d", t, n)
+			}
+		}
+		b.WriteByte('\n')
+	}
+	fmt.Fprintf(&b, "  Total cache: L1D %s, L1I %s, L2 %s, L3 %s\n",
+		humanBytes(s.TotalCache(1, Data)), humanBytes(s.TotalCache(1, Instruction)),
+		humanBytes(s.TotalCache(2, Unified)), humanBytes(s.TotalCache(3, Unified)))
+	return b.String()
+}
+
+func hasOnly(m map[CoreType]int, t CoreType) bool {
+	for k := range m {
+		if k != t {
+			return false
+		}
+	}
+	return true
+}
+
+func cacheSuffix(cs []Cache) string {
+	if len(cs) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(cs))
+	for _, c := range cs {
+		parts = append(parts, fmt.Sprintf("L%d%s %s", c.Level, cacheShort(c.Type), humanBytes(c.Size)))
+	}
+	return "  [" + strings.Join(parts, " ") + "]"
+}
+
+func cacheShort(t CacheType) string {
+	switch t {
+	case Data:
+		return "d"
+	case Instruction:
+		return "i"
+	}
+	return ""
+}
+
+func threadList(ts []Thread) string {
+	var b strings.Builder
+	for i, t := range ts {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, " %d", t.ID)
+	}
+	return b.String()
+}
+
+func humanBytes(b int) string {
+	switch {
+	case b <= 0:
+		return "0"
+	case b%(1<<20) == 0:
+		return fmt.Sprintf("%dMB", b>>20)
+	case b%(1<<10) == 0:
+		return fmt.Sprintf("%dKB", b>>10)
+	default:
+		return fmt.Sprintf("%dB", b)
+	}
+}

--- a/topology/topology_test.go
+++ b/topology/topology_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Klaus Post, released under MIT License. See LICENSE file.
+
+package topology_test
+
+import (
+	"testing"
+
+	"github.com/klauspost/cpuid/v2/internal/samplecpu"
+	"github.com/klauspost/cpuid/v2/topology"
+)
+
+func TestAggregates(t *testing.T) {
+	s := samplecpu.Topology()
+	if got := s.NumPackages(); got != 1 {
+		t.Errorf("NumPackages=%d want 1", got)
+	}
+	if got := s.NumCores(); got != 6 {
+		t.Errorf("NumCores=%d want 6", got)
+	}
+	if got := s.NumThreads(); got != 8 {
+		t.Errorf("NumThreads=%d want 8", got)
+	}
+	// Two L3 instances of 16MB, counted once each.
+	if got := s.TotalCache(3, topology.Unified); got != 32<<20 {
+		t.Errorf("TotalCache(L3)=%d want %d", got, 32<<20)
+	}
+	// Six per-core L2 instances of 1MB.
+	if got := s.TotalCache(2, topology.Unified); got != 6<<20 {
+		t.Errorf("TotalCache(L2)=%d want %d", got, 6<<20)
+	}
+	if bt := s.CoresByType(); bt[topology.Performance] != 2 || bt[topology.Efficiency] != 4 {
+		t.Errorf("CoresByType=%v want P:2 E:4", bt)
+	}
+}
+
+// TestSumBelowLevel checks that aggregates work at any level, so "total L3
+// under this group" and "under the whole system" are both answerable.
+func TestSumBelowLevel(t *testing.T) {
+	s := samplecpu.Topology()
+	g0 := &s.Packages[0].Groups[0]
+	if got := g0.TotalCache(3, topology.Unified); got != 16<<20 {
+		t.Errorf("group L3=%d want %d", got, 16<<20)
+	}
+	if got := g0.TotalCache(2, topology.Unified); got != 2<<20 {
+		t.Errorf("group L2=%d want %d", got, 2<<20)
+	}
+	if got := g0.NumThreads(); got != 4 {
+		t.Errorf("group threads=%d want 4", got)
+	}
+	if got := g0.NumCores(); got != 2 {
+		t.Errorf("group cores=%d want 2", got)
+	}
+	if got := s.Packages[0].NumCores(); got != 6 {
+		t.Errorf("package cores=%d want 6", got)
+	}
+}
+
+// TestSampleCacheOnce verifies no cache instance is counted twice: summing the
+// caches stored in the tree must equal the TotalCache aggregate.
+func TestSampleCacheOnce(t *testing.T) {
+	s := samplecpu.Topology()
+	sum := 0
+	for pi := range s.Packages {
+		p := &s.Packages[pi]
+		for _, c := range p.Caches {
+			sum += c.Size
+		}
+		for gi := range p.Groups {
+			g := &p.Groups[gi]
+			for _, c := range g.Caches {
+				sum += c.Size
+			}
+			for ci := range g.Cores {
+				for _, c := range g.Cores[ci].Caches {
+					sum += c.Size
+				}
+			}
+		}
+	}
+	total := s.TotalCache(1, topology.Data) + s.TotalCache(1, topology.Instruction) +
+		s.TotalCache(2, topology.Unified) + s.TotalCache(3, topology.Unified)
+	if sum != total {
+		t.Errorf("cache double-counted: tree sum %d != aggregate %d", sum, total)
+	}
+}
+
+func TestStringNoPanic(t *testing.T) {
+	if s := samplecpu.Topology().String(); len(s) == 0 {
+		t.Error("empty String()")
+	}
+}
+
+func TestEnumStrings(t *testing.T) {
+	if topology.Unified.String() != "Unified" || topology.Data.String() != "Data" || topology.Instruction.String() != "Instruction" {
+		t.Error("CacheType.String mismatch")
+	}
+	if topology.Performance.String() != "Performance" || topology.Efficiency.String() != "Efficiency" || topology.Unknown.String() != "Unknown" {
+		t.Error("CoreType.String mismatch")
+	}
+}

--- a/topology_scan.go
+++ b/topology_scan.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Klaus Post, released under MIT License. See LICENSE file.
+
+package cpuid
+
+import (
+	"errors"
+
+	"github.com/klauspost/cpuid/v2/topology"
+)
+
+// ErrTopologyScanUnavailable is returned by ScanTopology when a per-core scan
+// is not possible on the current platform, or CPU affinity could not be set.
+// The returned topology is then the extrapolated snapshot from CPU.Topology.
+var ErrTopologyScanUnavailable = errors.New("cpuid: per-core topology scan unavailable; returning extrapolated snapshot")
+
+// ScanTopology returns the exact CPU topology by reading CPUID on every online
+// logical processor.
+//
+// To sample each processor it locks the calling goroutine to an OS thread and
+// pins that thread to each CPU in turn, so it has transient scheduling side
+// effects. Call it explicitly when you need a precise tree (real
+// efficiency/performance core mapping, CCD membership); it is not run
+// automatically.
+//
+// It is supported on linux/amd64 and windows/amd64. On any other platform, or
+// if affinity cannot be set (e.g. a restrictive cgroup cpuset), it returns
+// CPU.Topology() together with ErrTopologyScanUnavailable.
+func ScanTopology() (*topology.System, error) {
+	cpus, err := scanLogicalCPUs()
+	if err != nil {
+		return CPU.Topology(), err
+	}
+	return assembleTopology(cpus), nil
+}

--- a/topology_scan_linux_amd64.go
+++ b/topology_scan_linux_amd64.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 Klaus Post, released under MIT License. See LICENSE file.
+
+//go:build linux && amd64 && !noasm && !appengine && !gccgo
+
+package cpuid
+
+import (
+	"runtime"
+
+	"golang.org/x/sys/unix"
+)
+
+// scanLogicalCPUs samples CPUID on every CPU in the calling thread's affinity
+// mask by pinning the thread to each in turn. sched_setaffinity migrates the
+// thread synchronously when its current CPU leaves the mask, so CPUID reflects
+// the intended processor once the call returns.
+func scanLogicalCPUs() ([]logicalCPU, error) {
+	var orig unix.CPUSet
+	if err := unix.SchedGetaffinity(0, &orig); err != nil {
+		return nil, ErrTopologyScanUnavailable
+	}
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	defer unix.SchedSetaffinity(0, &orig)
+
+	var cpus []logicalCPU
+	for i := range len(orig) * 64 {
+		if !orig.IsSet(i) {
+			continue
+		}
+		var set unix.CPUSet
+		set.Set(i)
+		if unix.SchedSetaffinity(0, &set) != nil {
+			continue
+		}
+		cpus = append(cpus, parseLogicalCPU())
+	}
+	if len(cpus) == 0 {
+		return nil, ErrTopologyScanUnavailable
+	}
+	return cpus, nil
+}

--- a/topology_scan_stub.go
+++ b/topology_scan_stub.go
@@ -1,0 +1,11 @@
+// Copyright (c) 2026 Klaus Post, released under MIT License. See LICENSE file.
+
+//go:build !amd64 || noasm || appengine || gccgo || (!linux && !windows)
+
+package cpuid
+
+// scanLogicalCPUs is unavailable on this platform; ScanTopology falls back to
+// the extrapolated snapshot.
+func scanLogicalCPUs() ([]logicalCPU, error) {
+	return nil, ErrTopologyScanUnavailable
+}

--- a/topology_scan_windows_amd64.go
+++ b/topology_scan_windows_amd64.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 Klaus Post, released under MIT License. See LICENSE file.
+
+//go:build windows && amd64 && !noasm && !appengine && !gccgo
+
+package cpuid
+
+import (
+	"runtime"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	kernel32                      = windows.NewLazySystemDLL("kernel32.dll")
+	procGetCurrentThread          = kernel32.NewProc("GetCurrentThread")
+	procGetCurrentProcess         = kernel32.NewProc("GetCurrentProcess")
+	procGetProcessAffinityMask    = kernel32.NewProc("GetProcessAffinityMask")
+	procSetThreadAffinityMask     = kernel32.NewProc("SetThreadAffinityMask")
+	procGetCurrentProcessorNumber = kernel32.NewProc("GetCurrentProcessorNumber")
+)
+
+// scanLogicalCPUs samples CPUID on every CPU in the process affinity mask by
+// pinning the current thread to each in turn. It covers a single processor
+// group (up to 64 logical CPUs); larger systems are not fully enumerated.
+func scanLogicalCPUs() ([]logicalCPU, error) {
+	proc, _, _ := procGetCurrentProcess.Call()
+	var procMask, sysMask uintptr
+	if ret, _, _ := procGetProcessAffinityMask.Call(proc, uintptr(unsafe.Pointer(&procMask)), uintptr(unsafe.Pointer(&sysMask))); ret == 0 || procMask == 0 {
+		return nil, ErrTopologyScanUnavailable
+	}
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	th, _, _ := procGetCurrentThread.Call()
+	defer procSetThreadAffinityMask.Call(th, procMask)
+
+	var cpus []logicalCPU
+	for i := range 64 {
+		bit := uintptr(1) << i
+		if procMask&bit == 0 {
+			continue
+		}
+		if prev, _, _ := procSetThreadAffinityMask.Call(th, bit); prev == 0 {
+			continue
+		}
+		// SetThreadAffinityMask may defer migration; wait until we are on CPU i.
+		for range 10000 {
+			if cur, _, _ := procGetCurrentProcessorNumber.Call(); uint32(cur) == uint32(i) {
+				break
+			}
+			runtime.Gosched()
+		}
+		cpus = append(cpus, parseLogicalCPU())
+	}
+	if len(cpus) == 0 {
+		return nil, ErrTopologyScanUnavailable
+	}
+	return cpus, nil
+}

--- a/topology_scan_windows_amd64.go
+++ b/topology_scan_windows_amd64.go
@@ -45,11 +45,17 @@ func scanLogicalCPUs() ([]logicalCPU, error) {
 			continue
 		}
 		// SetThreadAffinityMask may defer migration; wait until we are on CPU i.
+		// If it never lands there, skip it rather than record another CPU's data.
+		migrated := false
 		for range 10000 {
 			if cur, _, _ := procGetCurrentProcessorNumber.Call(); uint32(cur) == uint32(i) {
+				migrated = true
 				break
 			}
 			runtime.Gosched()
+		}
+		if !migrated {
+			continue
 		}
 		cpus = append(cpus, parseLogicalCPU())
 	}

--- a/topology_scan_windows_amd64.go
+++ b/topology_scan_windows_amd64.go
@@ -12,18 +12,27 @@ import (
 )
 
 var (
-	kernel32                      = windows.NewLazySystemDLL("kernel32.dll")
-	procGetCurrentThread          = kernel32.NewProc("GetCurrentThread")
-	procGetCurrentProcess         = kernel32.NewProc("GetCurrentProcess")
-	procGetProcessAffinityMask    = kernel32.NewProc("GetProcessAffinityMask")
-	procSetThreadAffinityMask     = kernel32.NewProc("SetThreadAffinityMask")
-	procGetCurrentProcessorNumber = kernel32.NewProc("GetCurrentProcessorNumber")
+	kernel32                       = windows.NewLazySystemDLL("kernel32.dll")
+	procGetCurrentThread           = kernel32.NewProc("GetCurrentThread")
+	procGetCurrentProcess          = kernel32.NewProc("GetCurrentProcess")
+	procGetProcessAffinityMask     = kernel32.NewProc("GetProcessAffinityMask")
+	procSetThreadAffinityMask      = kernel32.NewProc("SetThreadAffinityMask")
+	procGetCurrentProcessorNumber  = kernel32.NewProc("GetCurrentProcessorNumber")
+	procGetActiveProcessorGroupCnt = kernel32.NewProc("GetActiveProcessorGroupCount")
 )
 
 // scanLogicalCPUs samples CPUID on every CPU in the process affinity mask by
 // pinning the current thread to each in turn. It covers a single processor
 // group (up to 64 logical CPUs); larger systems are not fully enumerated.
 func scanLogicalCPUs() ([]logicalCPU, error) {
+	// A single process affinity mask only covers one processor group (<=64
+	// CPUs). Rather than record a partial tree on a machine with more than one
+	// group, bail out and let ScanTopology fall back to the snapshot, whose
+	// counts come from the (group-aware) OS totals.
+	if n, _, _ := procGetActiveProcessorGroupCnt.Call(); n > 1 {
+		return nil, ErrTopologyScanUnavailable
+	}
+
 	proc, _, _ := procGetCurrentProcess.Call()
 	var procMask, sysMask uintptr
 	if ret, _, _ := procGetProcessAffinityMask.Call(proc, uintptr(unsafe.Pointer(&procMask)), uintptr(unsafe.Pointer(&sysMask))); ret == 0 || procMask == 0 {

--- a/topology_test.go
+++ b/topology_test.go
@@ -1,0 +1,281 @@
+// Copyright (c) 2026 Klaus Post, released under MIT License. See LICENSE file.
+
+package cpuid
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/klauspost/cpuid/v2/topology"
+)
+
+// gtCPU is the ground truth for one logical processor, parsed from the
+// "allcpu: Package P / Core C / Thread T: ..., <type>" header the dumps carry.
+type gtCPU struct {
+	pkg, core, thread int
+	typ               topology.CoreType
+	valid             bool
+}
+
+type dumpCPU struct {
+	fake fakecpuid
+	gt   gtCPU
+}
+
+func parseAllcpu(s string, gt *gtCPU) {
+	if n, _ := fmt.Sscanf(s, "allcpu: Package %d / Core %d / Thread %d", &gt.pkg, &gt.core, &gt.thread); n != 3 {
+		return
+	}
+	gt.valid = true
+	switch {
+	case strings.Contains(s, "Intel Atom"):
+		gt.typ = topology.Efficiency
+	case strings.Contains(s, "Intel Core"):
+		gt.typ = topology.Performance
+	}
+}
+
+// parseCPUIDLine handles both dump formats: colon-separated
+// ("CPUID 0000000B: aaaa-bbbb-cccc-dddd [SL 00]") and the older tab/space
+// form ("CPUID 0000000B  \taaaa-bbbb-cccc-dddd").
+func parseCPUIDLine(line string, fake fakecpuid) {
+	rest := strings.TrimSpace(strings.TrimPrefix(line, "CPUID"))
+	i := strings.IndexAny(rest, " \t:")
+	if i < 0 {
+		return
+	}
+	var leaf uint32
+	if n, _ := fmt.Sscanf(rest[:i], "%x", &leaf); n != 1 {
+		return
+	}
+	vals := strings.TrimLeft(rest[i:], " \t:")
+	if j := strings.IndexByte(vals, '['); j >= 0 { // drop "[SL nn]" / "[name]" annotations
+		vals = vals[:j]
+	}
+	v := make([]uint32, 4)
+	if n, _ := fmt.Sscanf(vals, "%x-%x-%x-%x", &v[0], &v[1], &v[2], &v[3]); n != 4 {
+		if n, _ := fmt.Sscanf(vals, "%x %x %x %x", &v[0], &v[1], &v[2], &v[3]); n != 4 {
+			return
+		}
+	}
+	fake[leaf] = append(fake[leaf], v)
+}
+
+// parseDumpBlocks splits an instlatx64/AIDA64 dump into one entry per logical
+// processor. Each "CPUID Registers / Logical CPU #N" section becomes a block;
+// other sections (MSR, …) are ignored. Dumps without per-CPU sections are
+// returned as a single block.
+func parseDumpBlocks(def []byte) []dumpCPU {
+	lines := strings.Split(string(def), "\n")
+	var out []dumpCPU
+	var cur *dumpCPU
+	for _, line := range lines {
+		t := strings.TrimSpace(line)
+		switch {
+		case strings.Contains(t, "CPUID Registers"): // new CPU section (both formats)
+			out = append(out, dumpCPU{fake: fakecpuid{}})
+			cur = &out[len(out)-1]
+			continue
+		case strings.HasPrefix(t, "------[") || (strings.Contains(t, "Registers") && !strings.HasPrefix(t, "CPUID ")):
+			cur = nil // MSR/MTRR/other section
+			continue
+		}
+		if cur == nil {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(t, "allcpu:"):
+			parseAllcpu(t, &cur.gt)
+		case strings.HasPrefix(t, "CPUID "):
+			parseCPUIDLine(t, cur.fake)
+		}
+	}
+	// Old flat dumps have no per-CPU sections: treat the whole file as one CPU.
+	if len(out) == 0 {
+		d := dumpCPU{fake: fakecpuid{}}
+		for _, line := range lines {
+			if t := strings.TrimSpace(line); strings.HasPrefix(t, "CPUID ") {
+				parseCPUIDLine(t, d.fake)
+			}
+		}
+		if len(d.fake) > 0 {
+			out = append(out, d)
+		}
+	}
+	// Drop empty blocks (e.g. a header with no register lines).
+	filtered := out[:0]
+	for _, d := range out {
+		if len(d.fake) > 0 {
+			filtered = append(filtered, d)
+		}
+	}
+	return filtered
+}
+
+// installMock points the package CPUID functions at a single dump block.
+func installMock(fake fakecpuid) func() {
+	save := idfuncs{cpuid: cpuid, cpuidex: cpuidex, xgetbv: xgetbv}
+	cpuid = func(op uint32) (a, b, c, d uint32) {
+		if e := fake[op]; len(e) > 0 {
+			return e[0][0], e[0][1], e[0][2], e[0][3]
+		}
+		return 0, 0, 0, 0
+	}
+	cpuidex = func(op, op2 uint32) (a, b, c, d uint32) {
+		if e := fake[op]; int(op2) < len(e) {
+			return e[op2][0], e[op2][1], e[op2][2], e[op2][3]
+		}
+		return 0, 0, 0, 0
+	}
+	xgetbv = func(uint32) (uint32, uint32) { return 0, 0 }
+	return func() { cpuid, cpuidex, xgetbv = save.cpuid, save.cpuidex, save.xgetbv }
+}
+
+func buildTopologyFromDump(d []dumpCPU) ([]logicalCPU, *topology.System) {
+	recs := make([]logicalCPU, 0, len(d))
+	for i := range d {
+		restore := installMock(d[i].fake)
+		recs = append(recs, parseLogicalCPU())
+		restore()
+	}
+	return recs, assembleTopology(recs)
+}
+
+// uniqueAPICs reports whether every record has a distinct APIC id. Some
+// recorded dumps were captured without per-CPU affinity and repeat one id, so
+// their real core/package layout cannot be reconstructed.
+func uniqueAPICs(recs []logicalCPU) bool {
+	seen := make(map[uint32]bool, len(recs))
+	for _, r := range recs {
+		if seen[r.apicID] {
+			return false
+		}
+		seen[r.apicID] = true
+	}
+	return true
+}
+
+// TestTopologyDumps replays every recorded CPUID dump through the topology
+// builder and checks the result against the dumps' own ground-truth headers.
+func TestTopologyDumps(t *testing.T) {
+	zr, err := zip.OpenReader("testdata/cpuid_data.zip")
+	if err != nil {
+		t.Skip("No testdata:", err)
+	}
+	defer zr.Close()
+	defer Detect()
+
+	for _, f := range zr.File {
+		if !strings.HasSuffix(f.Name, ".txt") {
+			continue
+		}
+		t.Run(filepath.Base(f.Name), func(t *testing.T) {
+			rc, err := f.Open()
+			if err != nil {
+				t.Fatal(err)
+			}
+			content, err := io.ReadAll(rc)
+			rc.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+			cpus := parseDumpBlocks(content)
+			if len(cpus) == 0 {
+				t.Skip("no CPUID data")
+			}
+			recs, sys := buildTopologyFromDump(cpus)
+
+			// One thread per recorded logical CPU, always.
+			if got := sys.NumThreads(); got != len(cpus) {
+				t.Errorf("NumThreads()=%d, want %d\n%s", got, len(cpus), sys)
+			}
+			// No cache instance may be counted twice: the sum over the tree
+			// must equal the sum of every core-private plus group-shared cache.
+			checkCacheOnce(t, sys)
+
+			if !uniqueAPICs(recs) {
+				t.Skip("dump repeats APIC ids (captured without per-CPU affinity)")
+			}
+
+			// Compare against ground-truth headers when present on every block.
+			pkgs := map[int]bool{}
+			cores := map[[2]int]bool{}
+			typeOf := map[[2]int]topology.CoreType{}
+			pos := map[[3]int]bool{}
+			typed := false
+			for i := range cpus {
+				gt := cpus[i].gt
+				if !gt.valid {
+					return // no ground truth for this dump
+				}
+				tri := [3]int{gt.pkg, gt.core, gt.thread}
+				if pos[tri] {
+					t.Skipf("dump repeats logical position %v (inconsistent ground truth)", tri)
+				}
+				pos[tri] = true
+				pkgs[gt.pkg] = true
+				key := [2]int{gt.pkg, gt.core}
+				cores[key] = true
+				if gt.typ != topology.Unknown {
+					typed = true
+					typeOf[key] = gt.typ
+				}
+			}
+			if got := sys.NumPackages(); got != len(pkgs) {
+				t.Errorf("NumPackages()=%d, want %d", got, len(pkgs))
+			}
+			if got := sys.NumCores(); got != len(cores) {
+				t.Errorf("NumCores()=%d, want %d\n%s", got, len(cores), sys)
+			}
+			if typed {
+				want := map[topology.CoreType]int{}
+				for _, ct := range typeOf {
+					want[ct]++
+				}
+				got := sys.CoresByType()
+				for ct, n := range want {
+					if got[ct] != n {
+						t.Errorf("CoresByType()[%v]=%d, want %d", ct, got[ct], n)
+					}
+				}
+			}
+		})
+	}
+}
+
+// checkCacheOnce verifies TotalCache equals the independent sum of all caches
+// stored in the tree, i.e. that no instance is attached (and counted) twice.
+func checkCacheOnce(t *testing.T, sys *topology.System) {
+	t.Helper()
+	type lk struct {
+		level int
+		typ   topology.CacheType
+	}
+	want := map[lk]int{}
+	var walk func(cs []topology.Cache)
+	walk = func(cs []topology.Cache) {
+		for _, c := range cs {
+			want[lk{c.Level, c.Type}] += c.Size
+		}
+	}
+	for pi := range sys.Packages {
+		p := &sys.Packages[pi]
+		walk(p.Caches)
+		for gi := range p.Groups {
+			g := &p.Groups[gi]
+			walk(g.Caches)
+			for ci := range g.Cores {
+				walk(g.Cores[ci].Caches)
+			}
+		}
+	}
+	for k, size := range want {
+		if got := sys.TotalCache(k.level, k.typ); got != size {
+			t.Errorf("TotalCache(%d,%v)=%d, want %d", k.level, k.typ, got, size)
+		}
+	}
+}


### PR DESCRIPTION
Add a topology tree with a fixed hierarchy System → Package → Group → Core → Thread, where a Group is a last-level-cache (L3) sharing domain — an AMD CCX/CCD or an Intel LLC tile. Cores carry their type (performance/efficiency) and every level answers aggregate queries over what's below it (NumCores, NumThreads, CoresByType, TotalCache) without double-counting shared caches, so e.g. sys.TotalCache(3, Unified) is the total L3 across all CCDs.

- New topology sub-package: pure types + query methods + a tree String(); no dependencies of its own.
- CPUID parsing/assembly stays in package cpuid: x2APIC decomposition from leaves 0x1F/0x0B, cache sharing from 0x04/0x8000001D, hybrid core type from 0x1A, AMD node id and SMT from 0x8000001E.
- CPU.Topology(): cheap single-core snapshot (default, no thread pinning). ScanTopology(): opt-in exact per-core walk that pins to each CPU (linux/amd64, windows/amd64 via x/sys, already a dependency), falling back to the snapshot with ErrTopologyScanUnavailable elsewhere and on non-x86.
- cmd/cpuid: add -topology to print the tree and cache totals.
- Tests replay every recorded per-logical-CPU CPUID dump and validate the built tree against the dumps' Package/Core/Thread ground-truth headers; internal/samplecpu supplies a fixture for the unit tests and examples.

Example:

```
λ cpuid -topology
System: AMD (scanned) — 1 package(s), 16 core(s), 32 thread(s)
  Package #0
    Group #0  [L3 32MB]
      Core #0 (Performance) threads: 0, 1  [L1d 48KB L1i 32KB L2 1MB]
      Core #1 (Performance) threads: 2, 3  [L1d 48KB L1i 32KB L2 1MB]
      Core #2 (Performance) threads: 4, 5  [L1d 48KB L1i 32KB L2 1MB]
      Core #3 (Performance) threads: 6, 7  [L1d 48KB L1i 32KB L2 1MB]
      Core #4 (Performance) threads: 8, 9  [L1d 48KB L1i 32KB L2 1MB]
      Core #5 (Performance) threads: 10, 11  [L1d 48KB L1i 32KB L2 1MB]
      Core #6 (Performance) threads: 12, 13  [L1d 48KB L1i 32KB L2 1MB]
      Core #7 (Performance) threads: 14, 15  [L1d 48KB L1i 32KB L2 1MB]
    Group #1  [L3 32MB]
      Core #8 (Performance) threads: 16, 17  [L1d 48KB L1i 32KB L2 1MB]
      Core #9 (Performance) threads: 18, 19  [L1d 48KB L1i 32KB L2 1MB]
      Core #10 (Performance) threads: 20, 21  [L1d 48KB L1i 32KB L2 1MB]
      Core #11 (Performance) threads: 22, 23  [L1d 48KB L1i 32KB L2 1MB]
      Core #12 (Performance) threads: 24, 25  [L1d 48KB L1i 32KB L2 1MB]
      Core #13 (Performance) threads: 26, 27  [L1d 48KB L1i 32KB L2 1MB]
      Core #14 (Performance) threads: 28, 29  [L1d 48KB L1i 32KB L2 1MB]
      Core #15 (Performance) threads: 30, 31  [L1d 48KB L1i 32KB L2 1MB]
  Total cache: L1D 768KB, L1I 512KB, L2 16MB, L3 64MB
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CPU topology detection and reporting in a new topology API (system → package → group → core → thread) with cache summaries, NUMA grouping, and hybrid core types.
  * Introduced `ScanTopology()` with graceful fallback to an extrapolated snapshot.
  * Updated the CLI with a `-topology` option to display topology as text or indented JSON.
* **Bug Fixes**
  * CPU rescans now clear the cached topology snapshot before feature re-detection.
* **Tests**
  * Added topology unit tests and documentation-style examples, including fixture-driven validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->