### PR TITLE
fix: assign unified L1 cache size to L1D

### DIFF
--- a/cpuid.go
+++ b/cpuid.go
@@ -1226,10 +1226,14 @@ func (c *CPUInfo) cacheSize() {
 					// 2 = Instruction Cache
 					c.Cache.L1I = size
 				} else {
-					if c.Cache.L1D < 0 {
-						c.Cache.L1I = size
+					// Unified cache; apply to whichever of L1D/L1I is still
+					// unset. L1D/L1I are zeroed for Intel and pre-populated
+					// from CPUID 0x80000005 for AMD/Hygon, so check for both
+					// the -1 sentinel and an unset zero value.
+					if c.Cache.L1D <= 0 {
+						c.Cache.L1D = size
 					}
-					if c.Cache.L1I < 0 {
+					if c.Cache.L1I <= 0 {
 						c.Cache.L1I = size
 					}
 				}
@@ -1298,10 +1302,12 @@ func (c *CPUInfo) cacheSize() {
 					// Inst cache
 					c.Cache.L1I = size
 				default:
-					if c.Cache.L1D < 0 {
-						c.Cache.L1I = size
+					// Unified cache; apply to whichever of L1D/L1I is still
+					// unset (see the Intel path for the <= 0 rationale).
+					if c.Cache.L1D <= 0 {
+						c.Cache.L1D = size
 					}
-					if c.Cache.L1I < 0 {
+					if c.Cache.L1I <= 0 {
 						c.Cache.L1I = size
 					}
 				}


### PR DESCRIPTION
In the unified-cache fallback branch (cache type 3, neither Data nor Instruction), the code checked c.Cache.L1D < 0 but assigned to L1I, leaving L1D at its -1 sentinel on CPUs reporting a unified L1 cache and setting L1I twice. Assign to L1D in that branch to match the guard. Applies to both the Intel and AMD/Hygon paths.

Found by PostgresPro

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of “unspecified/unrecognized” L1 cache entries to prevent incorrect mapping between L1 data and L1 instruction sizes.
  * Ensured L1 cache size detection is applied to the correct L1 slot for Intel, AMD, and Hygon CPUs when only one side is still unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->