### PR TITLE
fix: trim surrounding space in ParseFeature

### DIFF
--- a/cpuid.go
+++ b/cpuid.go
@@ -958,7 +958,7 @@ func flagSetWith(feat ...FeatureID) flagSet {
 // ParseFeature will parse the string and return the ID of the matching feature.
 // Will return UNKNOWN if not found.
 func ParseFeature(s string) FeatureID {
-	s = strings.ToUpper(s)
+	s = strings.ToUpper(strings.TrimSpace(s))
 	for i := range lastID {
 		if i.String() == s {
 			return i

--- a/parsefeature_trim_test.go
+++ b/parsefeature_trim_test.go
@@ -1,0 +1,11 @@
+package cpuid
+
+import "testing"
+
+func TestParseFeatureTrimSpace(t *testing.T) {
+	s := SSE2.String()
+	got := ParseFeature("  " + s + " ")
+	if got != SSE2 {
+		t.Fatalf("got %v want SSE2 (%q)", got, s)
+	}
+}


### PR DESCRIPTION
## What

`ParseFeature` trims surrounding space before uppercasing and matching.

## Why

Feature names from flags/env often include padding.

## Test

- `TestParseFeatureTrimSpace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Feature-name parsing now accepts values with leading or trailing whitespace.
  * Existing feature matching behavior remains unchanged.

* **Tests**
  * Added coverage to verify whitespace is correctly ignored when parsing feature names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->